### PR TITLE
Fix server health metrics for single-data point sets

### DIFF
--- a/Core/World/C_ServerHealth.lua
+++ b/Core/World/C_ServerHealth.lua
@@ -46,6 +46,10 @@ function C_ServerHealth.ComputeMetricsOverInterval(observationIntervalInMillisec
 		error("Cannot compute server health metrics on an empty data set", 0)
 	end
 
+	if tickCount == 1 then
+		error("Cannot compute server health metrics for a single data point", 0)
+	end
+
 	local averageTickDuration = accumulatedTickDuration / tickCount
 
 	local minTickDuration = math_min(unpack(tickDurations))

--- a/Tests/WorldServer/C_ServerHealth.spec.lua
+++ b/Tests/WorldServer/C_ServerHealth.spec.lua
@@ -51,6 +51,17 @@ describe("C_ServerHealth", function()
 			assertThrows(computeMetricsOverZeroInterval, expectedErrorMessage)
 		end)
 
+		it("should throw when there is only a single data point", function()
+			local function computeMetricsOnSingleDataPoint()
+				C_ServerHealth.Reset()
+				C_ServerHealth.UpdateWithTickTime(1)
+				C_ServerHealth.ComputeMetricsOverInterval(123)
+			end
+			-- Technically, we could just set standardDeviation to zero, but computing metrics for one tick doesn't make sense
+			local expectedErrorMessage = "Cannot compute server health metrics for a single data point"
+			assertThrows(computeMetricsOnSingleDataPoint, expectedErrorMessage)
+		end)
+
 		it("should return a table with the updated metrics when the current data set is not empty", function()
 			C_ServerHealth.UpdateWithTickTime(44)
 			C_ServerHealth.UpdateWithTickTime(103)


### PR DESCRIPTION
See commit messages - this "fixes" the standard deviation being computed as "nan" (by failing loudly) as it's likely unintended.