### PR TITLE
Improve the performance of the update loop

### DIFF
--- a/Core/WorldServer.lua
+++ b/Core/WorldServer.lua
@@ -6,6 +6,7 @@ local C_ServerHealth = require("Core.World.C_ServerHealth")
 local TARGET_FPS = 50
 
 local WorldServer = {
+	worldStateUpdateTimer = nil,
 	tickTimeInMilliseconds = 1000 / TARGET_FPS,
 }
 
@@ -53,9 +54,9 @@ function WorldServer:HEALTH_STATUS_UPDATE(elapsedTimeInMilliseconds)
 end
 
 function WorldServer:StartGameLoop()
-	while true do
+	self.worldStateUpdateTimer = C_Timer.NewTicker(self.tickTimeInMilliseconds, function()
 		self:SimulateNextTick()
-	end
+	end)
 end
 
 function WorldServer:SimulateNextTick()
@@ -68,11 +69,6 @@ function WorldServer:SimulateNextTick()
 	local lastTickDurationInMilliseconds = lastTickDurationInNanoseconds / 10E5
 
 	C_ServerHealth.UpdateWithTickTime(lastTickDurationInMilliseconds)
-
-	local remainingTickTime = math.max(0, self.tickTimeInMilliseconds - lastTickDurationInMilliseconds)
-	uv.sleep(remainingTickTime)
-
-	uv.run("once") -- Will never get to the runtime's default loop, so poll manually
 end
 
 function WorldServer:CreateWorldState()


### PR DESCRIPTION
As a follow-up to #11, moving from a sleep-based to a timer-based loop seems to almost double the throughput.

Since the event loop sleeps internally anyway, this should be functionally identical and not cost (significantly) more CPU, so there's no reason to sleep manually here.

Unfortunately, testing timers is always icky, but degradation should be obvious if the target frame rate isn't reached (while idle).
