### PR TITLE
Set package.path explicity to avoid OS-dependent lookups

### DIFF
--- a/Tests/smoke-test.lua
+++ b/Tests/smoke-test.lua
@@ -1,3 +1,5 @@
+package.path = "?.lua"
+
 local specFiles = {
 	"Tests/DB/validate-creature-spawns.lua",
 	"Tests/RealmServer/serves-realm-list.lua",

--- a/Tests/unit-test.lua
+++ b/Tests/unit-test.lua
@@ -1,3 +1,5 @@
+package.path = "?.lua"
+
 local specFiles = {
 	"Tests/FileFormats/RagnarokGRF.spec.lua",
 	"Tests/WorldServer/C_ServerHealth.spec.lua",

--- a/main.lua
+++ b/main.lua
@@ -1,3 +1,5 @@
+package.path = "?.lua"
+
 local RealmServer = require("Core.RealmServer")
 local WorldServer = require("Core.WorldServer")
 


### PR DESCRIPTION
By default, the system LUA_PATH is used to determine the lookup path. While this works with a default configuration (as evidenced by CI runs), it's not guaranteed to work. Since the general assumption (for now) is to use standard require with relative paths from the project root, it would be prudent to make sure the lookups always succeed.