### PR TITLE
Fix GRF extraction for UTF8-encoded file paths

### DIFF
--- a/Core/FileFormats/RagnarokGRF.lua
+++ b/Core/FileFormats/RagnarokGRF.lua
@@ -198,9 +198,10 @@ end
 function RagnarokGRF:ExtractFileInMemory(fileName)
 	local timeBefore = uv.hrtime()
 
-	fileName = self:GetNormalizedFilePath(fileName)
+	local normalizedFileName = self:GetNormalizedFilePath(fileName)
 
-	local entry = self.fileTable.entries[fileName]
+	-- The name may already have been normalized if extracting based on the decoded file list
+	local entry = self.fileTable.entries[normalizedFileName] or self.fileTable.entries[fileName]
 	if not entry then
 		error("Failed to extract file " .. fileName .. " (no such entry exists)", 0)
 	end

--- a/Tests/FileFormats/RagnarokGRF.spec.lua
+++ b/Tests/FileFormats/RagnarokGRF.spec.lua
@@ -183,6 +183,19 @@ describe("RagnarokGRF", function()
 
 			assertEquals(fileContents, expectedFileContents)
 		end)
+
+		it("should accept normalized path names", function()
+			local grf = RagnarokGRF()
+			grf:Open("Tests/Fixtures/test.grf")
+			grf:ExtractFileToDisk("안녕하세요.txt", "안녕하세요.txt")
+			grf:Close()
+
+			local fileContents = C_FileSystem.ReadFile("안녕하세요.txt")
+			C_FileSystem.Delete("안녕하세요.txt")
+			local expectedFileContents = "안녕하십니까"
+
+			assertEquals(fileContents, expectedFileContents)
+		end)
 	end)
 
 	describe("IsFileEntry", function()


### PR DESCRIPTION
If the name has been normalized before, as is the case when using the file entry to extract all files from a given GRF archive, the lookup would fail because the UTF8-encoded name is again multibyte-decoded, which yields incorrect results.

Instead of doing fancy checks, let's keep it simple and assume that this is the only situation to deal with. Checking both entries while performing the lookup is the most straightforward solution.