### PR TITLE
Support additional media types in the asset server

### DIFF
--- a/Core/AssetServer.lua
+++ b/Core/AssetServer.lua
@@ -12,6 +12,13 @@ local AssetServer = {
 		[".html"] = "text/html",
 		[".css"] = "text/css",
 		[".js"] = "text/javascript",
+		[".wav"] = "audio/wav",
+		[".mp3"] = "audio/mpeg",
+		[".ogg"] = "audio/ogg",
+		[".png"] = "image/png",
+		[".jpg"] = "image/jpeg",
+		[".bmp"] = "image/bmp",
+		[".json"] = "application/json",
 	},
 }
 

--- a/Tests/AssetServer/AssetServer.spec.lua
+++ b/Tests/AssetServer/AssetServer.spec.lua
@@ -13,6 +13,13 @@ describe("AssetServer", function()
 				[".css"] = "text/css",
 				[".htm"] = "text/html",
 				[".html"] = "text/html",
+				[".wav"] = "audio/wav",
+				[".mp3"] = "audio/mpeg",
+				[".ogg"] = "audio/ogg",
+				[".png"] = "image/png",
+				[".jpg"] = "image/jpeg",
+				[".bmp"] = "image/bmp",
+				[".json"] = "application/json",
 			}
 
 			for extension, expectedContentType in pairs(supportedFileExtensions) do


### PR DESCRIPTION
The browser doesn't know what to do with them if the server doesn't set the appropriate content type header.