### PR TITLE
Prevent TypeScript from compiling the output bundle

### DIFF
--- a/Core/WebClient/tsconfig.json
+++ b/Core/WebClient/tsconfig.json
@@ -8,8 +8,6 @@
     "strict": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "allowJs": true,
-    "checkJs": true,
     "sourceMap": false,
     "declaration": true,
     "incremental": true,


### PR DESCRIPTION
No idea why it sometimes tries to do this, but it obviously won't work.