### PR TITLE
Set a default WebView window size so that fullscreen mode works on Mac OS

### DIFF
--- a/Core/WebClient.lua
+++ b/Core/WebClient.lua
@@ -9,6 +9,7 @@ function WebClient:Start()
 	C_WebView.NavigateToURL(htmlEntryPoint) -- Loading the HTML directly won't resolve external files (e.g., CSS)
 
 	C_WebView.SetWindowTitle("RagLite WebClient")
+	C_WebView.SetWindowSize(800, 600) -- OSX fullscreen won't work without explicit window sizes being set first
 	C_WebView.ToggleFullscreenMode()
 
 	-- Hacky, remove once JSON RPC is usable


### PR DESCRIPTION
It seems that the fullscreen mode on OSX is a bit odd: The runtime fails to show the window when no size has been specified, and then when it tries to toggle fullscreen mode it can't scale up the window (perhaps its size is initialised with zero?).

That aside, it's probably a good idea to set a default size anyway.