### PR TITLE
Rename the npm dev script so that it's easier to use

### DIFF
--- a/Core/WebClient/package.json
+++ b/Core/WebClient/package.json
@@ -10,7 +10,7 @@
     "build": "tsc && esbuild main.tsx --bundle --outfile=tsbuild/webclient.js --platform=browser --target=es2017 --jsx-factory=React.createElement --jsx-fragment=React.Fragment",
     "watch:build": "esbuild main.tsx --bundle --outfile=tsbuild/webclient.js --platform=browser --target=es2017 --jsx-factory=React.createElement --jsx-fragment=React.Fragment --watch",
     "watch:tsc": "tsc -w",
-    "dev": "concurrently npm:watch:*"
+    "start": "concurrently npm:watch:*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Starting the WebClient as a standalone app (without the Lua runtime) doesn't make any sense, and this is easier to type than "npm run dev".