### PR TITLE
Add a new route to the asset server that serves the GRF file list as JSON

### DIFF
--- a/Tests/AssetServer/serves-grf-index.lua
+++ b/Tests/AssetServer/serves-grf-index.lua
@@ -1,0 +1,65 @@
+local json = require("json")
+local uv = require("uv")
+
+local AssetServer = require("Core.AssetServer")
+local RagnarokGRF = require("Core.FileFormats.RagnarokGRF")
+
+AssetServer:Start("Tests/Fixtures/test.grf")
+
+local grf = RagnarokGRF()
+grf:Open("Tests/Fixtures/test.grf")
+
+local expectedFileList = json.parse('["subdirectory/hello.txt","hello-grf.txt","uppercase.png","안녕하세요.txt"]')
+table.sort(expectedFileList)
+local expectedFileContents = json.prettier(expectedFileList)
+
+local receivedChunks = buffer.new()
+
+local function assertFileListWasReceived(client)
+	local receivedData = tostring(receivedChunks)
+	local expectedContentLength = #expectedFileContents
+	local contentLength = tonumber(receivedData:match("Content%-Length: (%d+)"))
+	local contentType = receivedData:match("Content%-Type: application/json")
+	local status = receivedData:match("HTTP/1%.1 200 OK")
+	local responseBody = receivedData:sub(#receivedData - contentLength + 1)
+
+	assert(status == "HTTP/1.1 200 OK", "Should receive response with HTTP status 200 OK")
+	assert(contentType == "Content-Type: application/json", "Should receive response with the expected content type")
+	assert(contentLength == expectedContentLength, "Should receive the expected content length header")
+	assert(responseBody == expectedFileContents, "Should receive the file contents as stored within the archive")
+end
+
+local function createTestClient(requestURL)
+	local client = uv.new_tcp()
+	client:connect("127.0.0.1", AssetServer.DEFAULT_PORT, function()
+		client:read_start(function(err, chunk)
+			if err then
+				error(err, 0)
+				return
+			end
+
+			if not chunk then -- EOF
+				return
+			end
+
+			receivedChunks:put(chunk)
+		end)
+		client:write("GET " .. requestURL .. " HTTP/1.1\r\nHost: example.com\r\n\r\n")
+	end)
+
+	return client
+end
+
+local client = createTestClient("/")
+
+C_Timer.After(250, function()
+	client:shutdown()
+	client:close()
+
+	assertFileListWasReceived()
+
+	AssetServer:Stop()
+	grf:Close()
+end)
+
+uv.run()

--- a/Tests/smoke-test.lua
+++ b/Tests/smoke-test.lua
@@ -3,6 +3,7 @@ package.path = "?.lua"
 local specFiles = {
 	"Tests/AssetServer/404-not-found.lua",
 	"Tests/AssetServer/serves-grf-contents.lua",
+	"Tests/AssetServer/serves-grf-index.lua",
 	"Tests/AssetServer/serves-file-contents.lua",
 	"Tests/DB/validate-creature-spawns.lua",
 	"Tests/RealmServer/serves-realm-list.lua",


### PR DESCRIPTION
This allows the WebView to easily determine whether it's compatible with the GRF contents, request files, and aids debugging in general. Sending 10MB of JSON data around isn't really efficient, but it's not going over the network if using localhost, so whatever.