### PR TITLE
Implement virtual path lookups via custom uws route handlers in the asset server

### DIFF
--- a/Core/AssetServer.lua
+++ b/Core/AssetServer.lua
@@ -27,6 +27,7 @@ local AssetServer = {
 	routeHandlers = {
 		["/*"] = "FILE_DATA_REQUESTED",
 		["/"] = "GRF_FILE_LIST_REQUESTED",
+		["/ui/minimap/*"] = "MINIMAP_IMAGE_REQUESTED",
 	},
 }
 
@@ -99,6 +100,13 @@ function AssetServer:GRF_FILE_LIST_REQUESTED(requestID, requestedFilePath)
 	end
 
 	self:SendFileListAsJSON(requestID, requestedFilePath)
+end
+
+function AssetServer:MINIMAP_IMAGE_REQUESTED(requestID, requestedFilePath)
+	print("[AssetServer] MINIMAP_IMAGE_REQUESTED", requestID, requestedFilePath)
+
+	local minimapImagePath = requestedFilePath:gsub("/ui/minimap/", "data/texture/유저인터페이스/map/")
+	self:FILE_DATA_REQUESTED(requestID, minimapImagePath)
 end
 
 function AssetServer:FILE_DATA_REQUESTED(requestID, requestedFilePath)

--- a/Core/AssetServer.lua
+++ b/Core/AssetServer.lua
@@ -131,8 +131,11 @@ end
 function AssetServer:SendFileData(requestID, requestedFilePath)
 	print("[AssetServer] Serving file data in response to request " .. requestID)
 	local responseBody = self.grfArchive:ExtractFileInMemory(requestedFilePath)
+	local contentType = self:GetContentType(requestedFilePath)
+
 	self.webserver:WriteStatus(requestID, "200 OK")
-	self.webserver:WriteHeader(requestID, "Content-Type", "application/octet-stream")
+	self.webserver:WriteHeader(requestID, "Access-Control-Allow-Origin", "*") -- Avoid CORS issues in the WebView
+	self.webserver:WriteHeader(requestID, "Content-Type", contentType)
 	self.webserver:SendResponse(requestID, responseBody)
 
 	printf("[AssetServer] Responding with %s: %s", string_filesize(#responseBody), requestedFilePath)


### PR DESCRIPTION
As a basic test, a new `/ui/minimap` alias has been set up - which can only be tested manually for now.