### PR TITLE
Fix accidental camera resets via left-right click sequences

### DIFF
--- a/Core/NativeClient/NativeClient.lua
+++ b/Core/NativeClient/NativeClient.lua
@@ -430,9 +430,8 @@ function NativeClient:MOUSECLICK_STATUS_UPDATED(eventID, payload)
 		else
 			C_Camera.StopAdjustingView()
 		end
+		C_Cursor.SetClickTime(now)
 	end
-
-	C_Cursor.SetClickTime(now)
 end
 
 function NativeClient:CURSOR_MOVED(eventID, payload)

--- a/Tests/NativeClient/NativeClient.spec.lua
+++ b/Tests/NativeClient/NativeClient.spec.lua
@@ -146,5 +146,34 @@ describe("NativeClient", function()
 
 			assertEquals(C_Camera.GetHorizontalRotationAngle(), C_Camera.DEFAULT_HORIZONTAL_ROTATION)
 		end)
+
+		it("should not reset the horizontal camera rotation if a right-click follows a left click", function()
+			local event = ffi.new("deferred_event_t")
+			C_Cursor.SetClickTime(-2 * C_Cursor.DOUBLE_CLICK_TIME_IN_MILLISECONDS * 10E5)
+			C_Camera.ApplyHorizontalRotation(37) -- Arbitrary non-default rotation
+
+			-- RCLICK received -> should await second click
+			event.mouse_button_details.button = glfw.bindings.glfw_find_constant("GLFW_MOUSE_BUTTON_LEFT")
+			event.mouse_button_details.action = glfw.bindings.glfw_find_constant("GLFW_PRESS")
+			NativeClient:MOUSECLICK_STATUS_UPDATED("MOUSECLICK_STATUS_UPDATED", event)
+
+			event.mouse_button_details.button = glfw.bindings.glfw_find_constant("GLFW_MOUSE_BUTTON_LEFT")
+			event.mouse_button_details.action = glfw.bindings.glfw_find_constant("GLFW_RELEASE")
+			NativeClient:MOUSECLICK_STATUS_UPDATED("MOUSECLICK_STATUS_UPDATED", event)
+
+			assertFalse(C_Camera.GetHorizontalRotationAngle() == C_Camera.DEFAULT_HORIZONTAL_ROTATION)
+
+			-- Another RCLICK received -> should reset angle
+			-- Near-zero delay is inhumanely fast, so it should always be considered a double-click
+			event.mouse_button_details.button = glfw.bindings.glfw_find_constant("GLFW_MOUSE_BUTTON_RIGHT")
+			event.mouse_button_details.action = glfw.bindings.glfw_find_constant("GLFW_PRESS")
+			NativeClient:MOUSECLICK_STATUS_UPDATED("MOUSECLICK_STATUS_UPDATED", event)
+
+			event.mouse_button_details.button = glfw.bindings.glfw_find_constant("GLFW_MOUSE_BUTTON_RIGHT")
+			event.mouse_button_details.action = glfw.bindings.glfw_find_constant("GLFW_RELEASE")
+			NativeClient:MOUSECLICK_STATUS_UPDATED("MOUSECLICK_STATUS_UPDATED", event)
+
+			assertFalse(C_Camera.GetHorizontalRotationAngle() == C_Camera.DEFAULT_HORIZONTAL_ROTATION)
+		end)
 	end)
 end)


### PR DESCRIPTION
When pressing LEFT and then RIGHT, it shouldn't count as double click.