### PR TITLE
Speed up the initial loading time due to GRF file table decoding

### DIFF
--- a/Core/FileFormats/RagnarokGRF.lua
+++ b/Core/FileFormats/RagnarokGRF.lua
@@ -2,6 +2,7 @@ local bit = require("bit")
 local ffi = require("ffi")
 local uv = require("uv")
 local zlib = require("zlib")
+require("table.new")
 
 local tonumber = tonumber
 
@@ -142,7 +143,8 @@ function RagnarokGRF:DecodeFileEntries()
 
 	local movingConversionPointer = ffi_cast("char*", decompressedTableBytes)
 
-	local entries = {}
+	local entries = table.new(self.fileCount, 0)
+
 	for index = 0, self.fileCount - 1 do
 		local normalizedCaseInsensitiveFilePath, numProcessedBytesToSkip = self:DecodeFileName(movingConversionPointer)
 		movingConversionPointer = movingConversionPointer + numProcessedBytesToSkip + 1 -- \0 terminator

--- a/Core/FileFormats/RagnarokGRF.lua
+++ b/Core/FileFormats/RagnarokGRF.lua
@@ -253,16 +253,14 @@ if ffi.os == "Windows" then
 	local CP949 = 949
 	local CP_UTF8 = 65001
 
+	local maxLen = 1024
+	local unicodeStr = ffi.new("wchar_t[?]", maxLen)
+	local outputStr = ffi.new("char[?]", maxLen)
+
 	function RagnarokGRF:DecodeMultiByteString(input)
-		local unicodeLen = ffi.C.MultiByteToWideChar(CP949, 0, input, -1, nil, 0)
-		local unicodeStr = ffi.new("wchar_t[?]", unicodeLen)
-		ffi.C.MultiByteToWideChar(CP949, 0, input, -1, unicodeStr, unicodeLen)
-
-		local outputLen = ffi.C.WideCharToMultiByte(CP_UTF8, 0, unicodeStr, -1, nil, 0, nil, nil)
-		local outputStr = ffi.new("char[?]", outputLen)
-		ffi.C.WideCharToMultiByte(CP_UTF8, 0, unicodeStr, -1, outputStr, outputLen, nil, nil)
-
-		return ffi.string(outputStr)
+		ffi.C.MultiByteToWideChar(CP949, 0, input, -1, unicodeStr, maxLen)
+		ffi.C.WideCharToMultiByte(CP_UTF8, 0, unicodeStr, -1, outputStr, maxLen, nil, nil)
+		return ffi_string(outputStr)
 	end
 else
 	ffi.cdef([[


### PR DESCRIPTION
Still very slow, on the order of 750ms. About 550ms is just the inefficient file path normalization. Should improve that later.