### PR TITLE
Reduce the file table decoding time via further FFI calls

### DIFF
--- a/Core/RuntimeExtensions/cstring.lua
+++ b/Core/RuntimeExtensions/cstring.lua
@@ -1,0 +1,62 @@
+local ffi = require("ffi")
+
+ffi.cdef([[
+  size_t strlen(const char *str);
+  int tolower(int c);
+]])
+
+local cstring = {}
+
+function cstring.tolower(cstr, len)
+	for i = 0, len - 1 do
+		cstr[i] = ffi.C.tolower(cstr[i])
+	end
+end
+
+function cstring.size(cstr)
+	return tonumber(ffi.C.strlen(cstr))
+end
+
+local BACKSLASH = string.byte("\\")
+local FORWARD_SLASH = string.byte("/")
+
+function cstring.normalize(cstr, len)
+	local writeIndex = 0
+	local skipNext = false
+
+	for readIndex = 0, len - 1 do
+		local c = cstr[readIndex]
+
+		if c == BACKSLASH then
+			c = FORWARD_SLASH
+		end
+
+		if c == FORWARD_SLASH then
+			if skipNext then
+				-- Skip this character by not incrementing writeIndex.
+				skipNext = false
+			else
+				cstr[writeIndex] = c
+				writeIndex = writeIndex + 1
+				skipNext = true
+			end
+		else
+			skipNext = false
+			cstr[writeIndex] = c
+			writeIndex = writeIndex + 1
+		end
+	end
+
+	-- Handle the special case where the first character is a slash.
+	if cstr[0] == FORWARD_SLASH then
+		writeIndex = writeIndex - 1
+		for i = 0, writeIndex - 1 do
+			cstr[i] = cstr[i + 1]
+		end
+	end
+
+	-- Null-terminate the string.
+	cstr[writeIndex] = 0
+end
+
+return cstring

--- a/Tests/FileFormats/RagnarokGRF.spec.lua
+++ b/Tests/FileFormats/RagnarokGRF.spec.lua
@@ -263,4 +263,31 @@ describe("RagnarokGRF", function()
 			assertEquals(RagnarokGRF:GetNormalizedFilePath("hello\\\\world.txt"), "hello/world.txt")
 		end)
 	end)
+
+	describe("DecodeFileName", function()
+		local grf = RagnarokGRF()
+		it("should convert EUC-KR names to UTF8", function()
+			assertEquals(
+				grf:DecodeFileName("\xC0\xAF\xC0\xFA\xC0\xCE\xC5\xCD\xC6\xE4\xC0\xCC\xBD\xBA.txt"),
+				"유저인터페이스.txt"
+			)
+		end)
+
+		it("should convert upper-case to lower-case characters", function()
+			assertEquals(grf:DecodeFileName("TEST.BMP"), "test.bmp")
+		end)
+
+		it("should remove leading path separators", function()
+			-- These are added by the HTTP route handler, but they're useless for path lookups
+			assertEquals(grf:DecodeFileName("/hello/world.txt"), "hello/world.txt")
+		end)
+
+		it("should replace Windows path separators with POSIX ones", function()
+			assertEquals(grf:DecodeFileName("hello\\world.txt"), "hello/world.txt")
+		end)
+
+		it("should remove duplicate path separators", function()
+			assertEquals(grf:DecodeFileName("hello\\\\world.txt"), "hello/world.txt")
+		end)
+	end)
 end)


### PR DESCRIPTION
From 800ms to 400ms on my machine. Still not ideal, but even moving the code to C++ with iconv and preallocated buffers didn't help much, so might as well keep using the FFI for now. The iconv stuff should be moved to the runtime regardless (later).

Edit: This is on Windows. The iconv code needs a rework, but it's not that important right now. as I don't use WSL as often.