### PR TITLE
Streamline the graphics context stored in the WebGPU renderer

### DIFF
--- a/Core/NativeClient/NativeClient.lua
+++ b/Core/NativeClient/NativeClient.lua
@@ -11,16 +11,15 @@ local tonumber = tonumber
 
 local NativeClient = {
 	mainWindow = nil,
-	graphicsContext = nil,
 	deferredEventQueue = nil,
 }
 
 function NativeClient:Start()
 	self.mainWindow = self:CreateMainWindow()
-	self.graphicsContext = Renderer:CreateGraphicsContext(self.mainWindow)
-	Renderer:CreatePipelineConfigurations(self.graphicsContext)
-	Renderer:CreateUniformBuffer(self.graphicsContext)
-	Renderer:EnableDepthBuffer(self.graphicsContext)
+	Renderer:CreateGraphicsContext(self.mainWindow)
+	Renderer:CreatePipelineConfigurations()
+	Renderer:CreateUniformBuffer()
+	Renderer:EnableDepthBuffer()
 
 	-- Hardcoded for now, replace with actual geometry later
 	local PYRAMID_VERTEX_COUNT = 5
@@ -263,7 +262,7 @@ function NativeClient:Start()
 		PYRAMID_VERTEX_COUNT + 2 * ARROWHEAD_VERTEX_COUNT + 14,
 	}
 
-	Renderer:UploadGeometry(self.graphicsContext, vertexPositions, triangleIndices, vertexColorsRGB)
+	Renderer:UploadGeometry(vertexPositions, triangleIndices, vertexColorsRGB)
 
 	self:StartRenderLoop()
 end
@@ -317,7 +316,7 @@ function NativeClient:StartRenderLoop()
 	while glfw.bindings.glfw_window_should_close(self.mainWindow) == 0 do
 		glfw.bindings.glfw_poll_events()
 		self:ProcessWindowEvents()
-		Renderer:RenderNextFrame(self.graphicsContext)
+		Renderer:RenderNextFrame()
 	end
 end
 

--- a/Core/NativeClient/Renderer.lua
+++ b/Core/NativeClient/Renderer.lua
@@ -63,7 +63,7 @@ function Renderer:CreateGraphicsContext(nativeWindowHandle)
 
 	-- Updates to the backing window should be pushed via events, so only store the result here
 	self.wgpuSurface = glfw.bindings.glfw_get_wgpu_surface(context.instance, nativeWindowHandle)
-	self.viewportWidth, self.viewportHeight = self:GetSurfaceDimensions(nativeWindowHandle)
+	self.viewportWidth, self.viewportHeight = self:GetViewportSize(nativeWindowHandle)
 
 	-- In order to support window resizing, we'll need to re-create this on the fly (later)
 	context.swapChain = self:CreateSwapchain(context)
@@ -529,7 +529,7 @@ function Renderer:EnableDepthBuffer()
 	self.depthTextureView = depthTextureView
 end
 
-function Renderer:GetSurfaceDimensions(nativeWindowHandle)
+function Renderer:GetViewportSize(nativeWindowHandle)
 	-- Should probably differentiate between window and frame buffer here for high-DPI (later)
 	local contentWidthInPixels = ffi.new("int[1]")
 	local contentHeightInPixels = ffi.new("int[1]")


### PR DESCRIPTION
Still fairly verbose, but I don't know if moving the wgpu structs really helps with that. Maybe later, if things gets too out of hand.