### PR TITLE
Ensure high-powered WebGPU adapters are always requested

### DIFF
--- a/Core/NativeClient/WebGPU/GPU.lua
+++ b/Core/NativeClient/WebGPU/GPU.lua
@@ -19,6 +19,7 @@ function GPU:RequestAdapter(instance, window)
 
 	local adapterOptions = ffi.new("WGPURequestAdapterOptions")
 	adapterOptions.compatibleSurface = surface
+	adapterOptions.powerPreference = ffi.C.WGPUPowerPreference_HighPerformance
 
 	local requestedAdapter
 	local function onAdapterRequested(status, adapter, message, userdata)


### PR DESCRIPTION
It's implicitly assumed that we'll use a proper GPU, so fail if we can't.