### PR TITLE
Rename the aligned size field of GRF file entries

### DIFF
--- a/Core/FileFormats/RagnarokGRF.lua
+++ b/Core/FileFormats/RagnarokGRF.lua
@@ -159,7 +159,7 @@ function RagnarokGRF:DecodeFileEntries()
 		local fileEntry = {
 			name = normalizedCaseInsensitiveFilePath,
 			compressedSizeInBytes = tonumber(entry.compressed_size),
-			byteAlignedSizeInBytes = tonumber(entry.byte_aligned_size),
+			alignedSizeInBytes = tonumber(entry.byte_aligned_size),
 			decompressedSizeInBytes = tonumber(entry.decompressed_size),
 			typeID = tonumber(entry.node_type),
 			offsetRelativeToHeader = tonumber(entry.offset),
@@ -233,7 +233,7 @@ function RagnarokGRF:ExtractFileInMemory(fileName)
 
 	self.fileHandle:seek("set", entry.offsetRelativeToHeader + RagnarokGRF.HEADER_SIZE_IN_BYTES)
 
-	local buffer = self.fileHandle:read(entry.byteAlignedSizeInBytes) -- Padding is discarded by decompressor
+	local buffer = self.fileHandle:read(entry.alignedSizeInBytes) -- Padding is discarded by decompressor
 	if entry.typeID == RagnarokGRF.RAW_FILE_ENTRY_TYPE then
 		return buffer
 	end
@@ -249,7 +249,7 @@ function RagnarokGRF:ExtractFileInMemory(fileName)
 	printf(
 		"[RagnarokGRF] Blocking read for %.2f ms; decompressed %s in %.2f ms",
 		timeToRead,
-		string_filesize(entry.byteAlignedSizeInBytes),
+		string_filesize(entry.alignedSizeInBytes),
 		timeToDecompress
 	)
 

--- a/Tests/FileFormats/RagnarokGRF.spec.lua
+++ b/Tests/FileFormats/RagnarokGRF.spec.lua
@@ -37,19 +37,19 @@ describe("RagnarokGRF", function()
 			assertEquals(#grf.fileTable.entries, grf.fileCount)
 
 			assertEquals(grf.fileTable.entries["subdirectory/hello.txt"].compressedSizeInBytes, 82)
-			assertEquals(grf.fileTable.entries["subdirectory/hello.txt"].byteAlignedSizeInBytes, 88)
+			assertEquals(grf.fileTable.entries["subdirectory/hello.txt"].alignedSizeInBytes, 88)
 			assertEquals(grf.fileTable.entries["subdirectory/hello.txt"].decompressedSizeInBytes, 78) -- Not a bug; the text file is tiny
 			assertEquals(grf.fileTable.entries["subdirectory/hello.txt"].typeID, RagnarokGRF.COMPRESSED_FILE_ENTRY_TYPE)
 			assertEquals(grf.fileTable.entries["subdirectory/hello.txt"].offsetRelativeToHeader, 0)
 
 			assertEquals(grf.fileTable.entries["hello-grf.txt"].compressedSizeInBytes, 67)
-			assertEquals(grf.fileTable.entries["hello-grf.txt"].byteAlignedSizeInBytes, 72)
+			assertEquals(grf.fileTable.entries["hello-grf.txt"].alignedSizeInBytes, 72)
 			assertEquals(grf.fileTable.entries["hello-grf.txt"].decompressedSizeInBytes, 62) -- Not a bug; the text file is tiny
 			assertEquals(grf.fileTable.entries["hello-grf.txt"].typeID, RagnarokGRF.COMPRESSED_FILE_ENTRY_TYPE)
 			assertEquals(grf.fileTable.entries["hello-grf.txt"].offsetRelativeToHeader, 88)
 
 			assertEquals(grf.fileTable.entries["uppercase.png"].compressedSizeInBytes, 185) -- Should be normalized/lowercased in RAM
-			assertEquals(grf.fileTable.entries["uppercase.png"].byteAlignedSizeInBytes, 192)
+			assertEquals(grf.fileTable.entries["uppercase.png"].alignedSizeInBytes, 192)
 			assertEquals(grf.fileTable.entries["uppercase.png"].decompressedSizeInBytes, 189)
 			assertEquals(grf.fileTable.entries["uppercase.png"].typeID, RagnarokGRF.COMPRESSED_FILE_ENTRY_TYPE)
 			assertEquals(grf.fileTable.entries["uppercase.png"].offsetRelativeToHeader, 160)
@@ -66,7 +66,7 @@ describe("RagnarokGRF", function()
 
 			assertEquals(fileEntry.name, "uppercase.png")
 			assertEquals(fileEntry.compressedSizeInBytes, 185)
-			assertEquals(fileEntry.byteAlignedSizeInBytes, 192)
+			assertEquals(fileEntry.alignedSizeInBytes, 192)
 			assertEquals(fileEntry.decompressedSizeInBytes, 189)
 			assertEquals(fileEntry.typeID, RagnarokGRF.COMPRESSED_FILE_ENTRY_TYPE)
 			assertEquals(fileEntry.offsetRelativeToHeader, 160)


### PR DESCRIPTION
Maybe it's OCD, but this just seems a bit too awkward for my taste.