### PR TITLE
Add a new FFI-based decoder for GR2 files

### DIFF
--- a/Core/FileFormats/RagnarokGR2.lua
+++ b/Core/FileFormats/RagnarokGR2.lua
@@ -1,0 +1,244 @@
+local BinaryReader = require("Core.FileFormats.BinaryReader")
+
+local openssl = require("openssl")
+local uv = require("uv")
+
+local RagnarokGR2 = {
+	MAGIC_HEADER = string.lower("B867B0CAF86DB10F84728C7E5E19001E"),
+	COMPRESSION_MODE_NONE = 0,
+	COMPRESSION_MODE_OODLE = 1,
+}
+
+function RagnarokGR2:Construct()
+	local instance = {}
+
+	setmetatable(instance, self)
+
+	return instance
+end
+
+function RagnarokGR2:DecodeFileContents(fileContents)
+	local startTime = uv.hrtime()
+
+	self.reader = BinaryReader(fileContents)
+
+	self:DecodeFileHeader()
+	self:DecodeSegmentHeaders()
+	self:DecodeDataSegments()
+
+	local numBytesRemaining = self.reader.endOfFilePointer - self.reader.virtualFilePointer
+	local eofErrorMessage = format("Detected %s leftover bytes at the end of the structure!", numBytesRemaining)
+	assert(self.reader:HasReachedEOF(), eofErrorMessage)
+
+	local endTime = uv.hrtime()
+	local decodingTimeInMilliseconds = (endTime - startTime) / 10E5
+	printf("[RagnarokGR2] Finished decoding file contents in %.2f ms", decodingTimeInMilliseconds)
+end
+
+function RagnarokGR2:DecodeFileHeader()
+	local reader = self.reader
+
+	self.signature = openssl.hex(reader:GetCountedString(16))
+	if self.signature ~= RagnarokGR2.MAGIC_HEADER then
+		error(
+			format(
+				"Failed to decode GR2 header (Signature " .. self.signature .. ' should be "%s")',
+				RagnarokGR2.MAGIC_HEADER
+			),
+			0
+		)
+	end
+
+	self.headerSizeInBytes = reader:GetUnsignedInt32()
+	assert(
+		self.headerSizeInBytes == 352,
+		format("Unexpected header size %s (should probably investigate?)", self.headerSizeInBytes)
+	)
+	self.unknownHeaderBytes = { -- Format identifier? (OpenGR2) -> Whatever, doesn't matter if it's always zero...
+		reader:GetUnsignedInt32(),
+		reader:GetUnsignedInt32(),
+		reader:GetUnsignedInt32(),
+	}
+	assert(self.unknownHeaderBytes[1] == 0, "Unknown header bytes #1 are non-zero (should probably investigate?)")
+	assert(self.unknownHeaderBytes[2] == 0, "Unknown header bytes #2 are non-zero (should probably investigate?)")
+	assert(self.unknownHeaderBytes[3] == 0, "Unknown header bytes #3 are non-zero (should probably investigate?)")
+
+	self.version = reader:GetUnsignedInt32()
+	if self.version ~= 6.0 then
+		error(format("Unsupported GR2 version %.1f", self.version), 0)
+	end
+
+	self.totalFileSizeInBytes = reader:GetUnsignedInt32()
+	assert(
+		self.totalFileSizeInBytes == reader.endOfFilePointer,
+		format(
+			"Stored GR2 file size %s doesn't match actual size %s",
+			self.totalFileSizeInBytes,
+			reader.endOfFilePointer
+		)
+	)
+
+	self.checksum = reader:GetUnsignedInt32()
+
+	self.segmentHeadersOffsetRelativeToFileHeader = reader:GetUnsignedInt32()
+	self.numDataSegments = reader:GetUnsignedInt32()
+
+	self.rootNodeInfo = {
+		pointerToTypeNode = {
+			dataSegmentID = reader:GetUnsignedInt32(),
+			offsetFromStartOfSegment = reader:GetUnsignedInt32(),
+		},
+		pointerToRootNode = {
+			dataSegmentID = reader:GetUnsignedInt32(),
+			offsetFromStartOfSegment = reader:GetUnsignedInt32(),
+		},
+		versionTag = reader:GetUnsignedInt32(),
+		customizedVersionTags = {
+			reader:GetUnsignedInt32(),
+			reader:GetUnsignedInt32(),
+			reader:GetUnsignedInt32(),
+			reader:GetUnsignedInt32(),
+		},
+	}
+
+	assert(
+		self.rootNodeInfo.versionTag == 2147483663,
+		format("Unexpected root node version %s (should be %s)", self.rootNodeInfo.version, 2147483663)
+	)
+	assert(
+		self.rootNodeInfo.customizedVersionTags[1] == 0,
+		"Customized version tag #1 is non-zero (should probably investigate?)"
+	)
+	assert(
+		self.rootNodeInfo.customizedVersionTags[2] == 0,
+		"Customized version tag #2 is non-zero (should probably investigate?)"
+	)
+	assert(
+		self.rootNodeInfo.customizedVersionTags[3] == 0,
+		"Customized version tag #3 is non-zero (should probably investigate?)"
+	)
+	assert(
+		self.rootNodeInfo.customizedVersionTags[4] == 0,
+		"Customized version tag #4 is non-zero (should probably investigate?)"
+	)
+end
+
+function RagnarokGR2:DecodeSegmentHeaders()
+	local reader = self.reader
+
+	local segmentHeaders = {}
+
+	for segmentID = 1, self.numDataSegments do
+		local segmentHeader = {
+			compressionTypeID = reader:GetUnsignedInt32(),
+			startOffsetRelativeToFile = reader:GetUnsignedInt32(),
+			compressedSizeInBytes = reader:GetUnsignedInt32(),
+			decompressedSizeInBytes = reader:GetUnsignedInt32(),
+			alignmentInBytes = reader:GetUnsignedInt32(),
+			compressorParameters = {
+				firstTrackEndOffsetRelativeToSegment = reader:GetUnsignedInt32(),
+				secondTrackEndOffsetRelativeToSegment = reader:GetUnsignedInt32(),
+			},
+			virtualPointerRelocationInfo = {
+				offsetRelativeToFile = reader:GetUnsignedInt32(),
+				numRequiredRelocations = reader:GetUnsignedInt32(),
+			},
+			endiannessRelocationInfo = {
+				offsetRelativeToFile = reader:GetUnsignedInt32(),
+				numRequiredRelocations = reader:GetUnsignedInt32(),
+			},
+		}
+
+		table.insert(segmentHeaders, segmentHeader)
+	end
+
+	self.segmentHeaders = segmentHeaders
+end
+
+function RagnarokGR2:DecodeDataSegments()
+	local reader = self.reader
+
+	local dataSegments = {}
+
+	for segmentID = 1, self.numDataSegments do
+		local segment = {
+			virtualPointerRelocations = {},
+			endiannessRelocations = {},
+		}
+
+		local header = self.segmentHeaders[segmentID]
+		local isCompressedSegment = (header.compressionTypeID ~= RagnarokGR2.COMPRESSION_MODE_NONE)
+		printf(
+			"[RagnarokGR2] NYI: Decoding %s data segment %d (offset: %s, compression mode: %d, compressed size: %s, decompressed size: %s, alignment: %s)",
+			isCompressedSegment and "compressed" or "uncompressed",
+			segmentID,
+			header.startOffsetRelativeToFile,
+			header.compressionTypeID,
+			header.compressedSizeInBytes,
+			header.decompressedSizeInBytes,
+			header.alignmentInBytes
+		)
+
+		local numRequiredPointerRelocations = header.virtualPointerRelocationInfo.numRequiredRelocations
+		printf("[RagnarokGR2] NYI: This segment requires %d pointer relocations", numRequiredPointerRelocations)
+
+		for relocationID = 1, numRequiredPointerRelocations do
+			local virtualPointerRelocationInfo = {
+				fromOffsetRelativeToSegment = reader:GetUnsignedInt32(),
+				targetSegmentID = reader:GetUnsignedInt32(),
+				destinationOffsetRelativeToTargetSegment = reader:GetUnsignedInt32(),
+			}
+			table.insert(segment.virtualPointerRelocations, virtualPointerRelocationInfo)
+		end
+
+		local numRequiredEndiannessRelocations = header.endiannessRelocationInfo.numRequiredRelocations
+		printf("[RagnarokGR2] NYI: This segment requires %d endianness relocations", numRequiredEndiannessRelocations)
+		for relocationID = 1, numRequiredEndiannessRelocations do
+			local endiannessRelocationInfo = {
+				numEntriesToFix = reader:GetUnsignedInt32(), -- Entries = ? (unclear, should clarify later)
+				startOffset = reader:GetUnsignedInt32(),
+				targetSegmentID = reader:GetUnsignedInt32(),
+				targetOffset = reader:GetUnsignedInt32(),
+			}
+
+			table.insert(segment.endiannessRelocations, endiannessRelocationInfo)
+		end
+
+		local segmentBytes = buffer.new(header.decompressedSizeInBytes)
+		segmentBytes:put(reader:GetCountedString(header.compressedSizeInBytes))
+		printf("[RagnarokGR2] Exporting %s data segment (for further analysis)", string.filesize(#segmentBytes))
+
+		-- Cannot proceed here, for now (since Oodle decompression and relocations aren't supported)
+		segment.bytes = debug.sbuf(segmentBytes) -- Not particularly useful, but oh well
+
+		table.insert(dataSegments, segment)
+	end
+
+	self.dataSegments = dataSegments
+end
+
+local json = require("json")
+
+function RagnarokGR2:ToJSON()
+	local gr2 = {
+		signature = self.signature,
+		headerSizeInBytes = self.headerSizeInBytes,
+		unknownHeaderBytes = self.unknownHeaderBytes,
+		version = self.version,
+		totalFileSizeInBytes = self.totalFileSizeInBytes,
+		checksum = self.checksum,
+		segmentHeadersOffsetRelativeToFileHeader = self.segmentHeadersOffsetRelativeToFileHeader,
+		numDataSegments = self.numDataSegments,
+		rootNodeInfo = self.rootNodeInfo,
+		segmentHeaders = self.segmentHeaders,
+		dataSegments = self.dataSegments,
+	}
+
+	return json.prettier(gr2)
+end
+
+RagnarokGR2.__index = RagnarokGR2
+RagnarokGR2.__call = RagnarokGR2.Construct
+setmetatable(RagnarokGR2, RagnarokGR2)
+
+return RagnarokGR2

--- a/Tests/FileFormats/RagnarokGR2.spec.lua
+++ b/Tests/FileFormats/RagnarokGR2.spec.lua
@@ -1,0 +1,69 @@
+local RagnarokGR2 = require("Core.FileFormats.RagnarokGR2")
+local RagnarokGRF = require("Core.FileFormats.RagnarokGRF")
+
+local miniz = require("miniz")
+local transform = require("transform")
+
+local GRF_GR2_BASE_PATH = "data/model/3dmob/"
+local GRF_GR2_SKELETONS_PATH = "data/model/3dmob_bone/"
+
+local grannyFilesList = {
+	{ file = GRF_GR2_BASE_PATH .. "aguardian90_8.gr2", checksum = 3613547, jsonSize = 558140 },
+	{ file = GRF_GR2_BASE_PATH .. "empelium90_0.gr2", checksum = 2362359871, jsonSize = 210665 },
+	{ file = GRF_GR2_BASE_PATH .. "guildflag90_1.gr2", checksum = 1924535745, jsonSize = 266810 },
+	{ file = GRF_GR2_BASE_PATH .. "kguardian90_7.gr2", checksum = 3216031845, jsonSize = 538284 },
+	{ file = GRF_GR2_BASE_PATH .. "sguardian90_9.gr2", checksum = 3977127686, jsonSize = 494673 },
+	{ file = GRF_GR2_BASE_PATH .. "treasurebox_2.gr2", checksum = 2106457723, jsonSize = 184591 },
+
+	{ file = GRF_GR2_SKELETONS_PATH .. "1_attack.gr2", checksum = 4117355684, jsonSize = 567068 },
+	{ file = GRF_GR2_SKELETONS_PATH .. "2_damage.gr2", checksum = 1139923259, jsonSize = 97404 },
+	{ file = GRF_GR2_SKELETONS_PATH .. "2_dead.gr2", checksum = 1116660203, jsonSize = 126951 },
+	{ file = GRF_GR2_SKELETONS_PATH .. "7_attack.gr2", checksum = 1868355480, jsonSize = 177638 },
+	{ file = GRF_GR2_SKELETONS_PATH .. "7_damage.gr2", checksum = 655650119, jsonSize = 204278 },
+	{ file = GRF_GR2_SKELETONS_PATH .. "7_dead.gr2", checksum = 3026864945, jsonSize = 251174 },
+	{ file = GRF_GR2_SKELETONS_PATH .. "7_move.gr2", checksum = 2884345469, jsonSize = 206654 },
+	{ file = GRF_GR2_SKELETONS_PATH .. "8_attack.gr2", checksum = 3744560610, jsonSize = 243809 },
+	{ file = GRF_GR2_SKELETONS_PATH .. "8_damage.gr2", checksum = 22355839, jsonSize = 176141 },
+	{ file = GRF_GR2_SKELETONS_PATH .. "8_dead.gr2", checksum = 4059769579, jsonSize = 209788 },
+	{ file = GRF_GR2_SKELETONS_PATH .. "8_move.gr2", checksum = 3763830390, jsonSize = 203080 },
+	{ file = GRF_GR2_SKELETONS_PATH .. "9_attack.gr2", checksum = 441125228, jsonSize = 160745 },
+	{ file = GRF_GR2_SKELETONS_PATH .. "9_damage.gr2", checksum = 1688440907, jsonSize = 181409 },
+	{ file = GRF_GR2_SKELETONS_PATH .. "9_dead.gr2", checksum = 259586279, jsonSize = 225375 },
+	{ file = GRF_GR2_SKELETONS_PATH .. "9_move.gr2", checksum = 3160164003, jsonSize = 185812 },
+}
+
+describe("RagnarokGR2", function()
+	local grfPath = "data.grf"
+	if not C_FileSystem.Exists(grfPath) then
+		transform.yellow("Warning: Skipped GR2 decoder test (data.grf file not present)")
+		return
+	end
+
+	local grf = RagnarokGRF()
+	grf:Open(grfPath) -- Leave this handle open to speed up the test (OS will clean up on exit, presumably)
+	before(function() end)
+
+	describe("DecodeFileContents", function()
+		assertEquals(#grannyFilesList, 21)
+
+		for index, testCase in pairs(grannyFilesList) do
+			local expectedChecksum = testCase.checksum
+			local expectedLength = testCase.jsonSize
+			local gr2FilePath = testCase.file
+
+			it("should be able to decode " .. gr2FilePath, function()
+				-- This is quite hacky, but far easier than comparing everything in excruciating details
+				-- Ideally, there should be a test.gr2 file that covers, but creating one would be quite laborious...
+				local gr2 = RagnarokGR2()
+
+				local gr2Bytes = grf:ExtractFileInMemory(gr2FilePath)
+				gr2:DecodeFileContents(gr2Bytes)
+
+				local jsonString = gr2:ToJSON()
+				assertEquals(#jsonString, expectedLength)
+				local checksum = miniz.crc32(0, jsonString)
+				assertEquals(checksum, expectedChecksum)
+			end)
+		end
+	end)
+end)

--- a/Tests/unit-test.lua
+++ b/Tests/unit-test.lua
@@ -3,6 +3,7 @@ package.path = "?.lua"
 local specFiles = {
 	"Tests/FileFormats/BinaryReader.spec.lua",
 	"Tests/FileFormats/RagnarokGND.spec.lua",
+	"Tests/FileFormats/RagnarokGR2.spec.lua",
 	"Tests/FileFormats/RagnarokGRF.spec.lua",
 	"Tests/FileFormats/RagnarokPAL.spec.lua",
 	"Tests/FileFormats/RagnarokRSW.spec.lua",

--- a/Tools/gr2-to-json.lua
+++ b/Tools/gr2-to-json.lua
@@ -1,0 +1,36 @@
+local RagnarokGR2 = require("Core.FileFormats.RagnarokGR2")
+local RagnarokGRF = require("Core.FileFormats.RagnarokGRF")
+
+local grfPath = "data.grf"
+local grf = RagnarokGRF()
+grf:Open(grfPath)
+
+local filesToExport = {}
+
+if not arg[1] then
+	print("No args provided, exporting all discovered .gr2 files")
+	local fileList = grf:GetFileList()
+	for grfFilePath, entry in pairs(fileList) do
+		if path.extname(grfFilePath) == ".gr2" then
+			printf("Discovered relevant file: %s", grfFilePath)
+			table.insert(filesToExport, grfFilePath)
+		end
+	end
+else
+	print("%s arguments provided, exporting those", #arg)
+	dump(arg)
+	filesToExport = unpack(arg)
+end
+
+for index, gr2FilePath in ipairs(filesToExport) do
+	printf("Dumping GR2 contents: %s", gr2FilePath)
+
+	local gr2Bytes = grf:ExtractFileInMemory(gr2FilePath)
+	local gr2 = RagnarokGR2()
+	gr2:DecodeFileContents(gr2Bytes)
+
+	local exportFilePathRoot = path.join("Exports", path.basename(gr2FilePath) .. ".json")
+	C_FileSystem.WriteFile(exportFilePathRoot, gr2:ToJSON())
+end
+
+grf:Close()


### PR DESCRIPTION
Doesn't process the data segments, just the outer structures (as described by OpenGR2).

It's probably also wrong in some aspects, but there's no telling anyway until further analysis has been performed.