### PR TITLE
Add a missing EOF sanity check to the SPR and GND decoders

### DIFF
--- a/Core/FileFormats/RagnarokGND.lua
+++ b/Core/FileFormats/RagnarokGND.lua
@@ -111,6 +111,10 @@ function RagnarokGND:DecodeFileContents(fileContents)
 	self:DecodeCubeGrid()
 	self:DecodeWaterPlanes()
 
+	local numBytesRemaining = self.reader.endOfFilePointer - self.reader.virtualFilePointer
+	local eofErrorMessage = format("Detected %s leftover bytes at the end of the structure!", numBytesRemaining)
+	assert(self.reader:HasReachedEOF(), eofErrorMessage)
+
 	local endTime = uv.hrtime()
 	local decodingTimeInMilliseconds = (endTime - startTime) / 10E5
 	printf("[RagnarokGND] Finished decoding file contents in %.2f ms", decodingTimeInMilliseconds)

--- a/Core/FileFormats/RagnarokSPR.lua
+++ b/Core/FileFormats/RagnarokSPR.lua
@@ -41,6 +41,10 @@ function RagnarokSPR:DecodeFileContents(fileContents)
 	self:DecodeTrueColorImages()
 	self:DecodeColorPalette()
 
+	local numBytesRemaining = self.reader.endOfFilePointer - self.reader.virtualFilePointer
+	local eofErrorMessage = format("Detected %s leftover bytes at the end of the structure!", numBytesRemaining)
+	assert(self.reader:HasReachedEOF(), eofErrorMessage)
+
 	local endTime = uv_hrtime()
 	local decodingTimeInMilliseconds = (endTime - startTime) / 10E5
 	printf("[RagnarokSPR] Finished decoding file contents in %.2f ms", decodingTimeInMilliseconds)


### PR DESCRIPTION
Should've been there from the start.