### PR TITLE
Remove an empty setup function from the GR2 tests

### DIFF
--- a/Tests/FileFormats/RagnarokGR2.spec.lua
+++ b/Tests/FileFormats/RagnarokGR2.spec.lua
@@ -41,7 +41,6 @@ describe("RagnarokGR2", function()
 
 	local grf = RagnarokGRF()
 	grf:Open(grfPath) -- Leave this handle open to speed up the test (OS will clean up on exit, presumably)
-	before(function() end)
 
 	describe("DecodeFileContents", function()
 		assertEquals(#grannyFilesList, 21)


### PR DESCRIPTION
Seems like an oversight. No point in keeping this around.