### PR TITLE
Extend the runtime to allow detecting test runs

### DIFF
--- a/Core/RuntimeExtensions/C_Runtime.lua
+++ b/Core/RuntimeExtensions/C_Runtime.lua
@@ -1,0 +1,31 @@
+function C_Runtime.IsTesting()
+	return C_Runtime.isTestRun
+end
+
+local RunBasicTests = C_Runtime.RunBasicTests
+function C_Runtime.RunBasicTests(...)
+	printf("[C_Runtime] BASIC test run detected - some functionality may not be available in this mode")
+	C_Runtime.isTestRun = true
+	return RunBasicTests(...)
+end
+
+local RunDetailedTests = C_Runtime.RunDetailedTests
+function C_Runtime.RunDetailedTests(...)
+	printf("[C_Runtime] DETAILED test run detected - some functionality may not be available in this mode")
+	C_Runtime.isTestRun = true
+	return RunDetailedTests(...)
+end
+
+local RunMinimalTests = C_Runtime.RunMinimalTests
+function C_Runtime.RunSnapshotTests(...)
+	printf("[C_Runtime] MINIMAL test run detected - some functionality may not be available in this mode")
+	C_Runtime.isTestRun = true
+	return RunMinimalTests(...)
+end
+
+local RunSnapshotTests = C_Runtime.RunSnapshotTests
+function C_Runtime.RunSnapshotTests(...)
+	printf("[C_Runtime] SNAPSHOT test run detected - some functionality may not be available in this mode")
+	C_Runtime.isTestRun = true
+	return RunSnapshotTests(...)
+end

--- a/Tests/RuntimeExtensions/C_Runtime.spec.lua
+++ b/Tests/RuntimeExtensions/C_Runtime.spec.lua
@@ -1,0 +1,7 @@
+describe("C_Runtime", function()
+	describe("IsTesting", function()
+		it("should return true while the test runner is active", function()
+			assertTrue(C_Runtime.IsTesting())
+		end)
+	end)
+end)

--- a/Tests/unit-test.lua
+++ b/Tests/unit-test.lua
@@ -1,5 +1,7 @@
 package.path = "?.lua"
 
+require("Core.RuntimeExtensions.C_Runtime")
+
 local specFiles = {
 	"Tests/FileFormats/BinaryReader.spec.lua",
 	"Tests/FileFormats/RagnarokACT.spec.lua",
@@ -12,6 +14,7 @@ local specFiles = {
 	"Tests/FileFormats/RagnarokRSW.spec.lua",
 	"Tests/FileFormats/RagnarokSPR.spec.lua",
 	"Tests/FileFormats/RSW/QuadTreeRange.spec.lua",
+	"Tests/RuntimeExtensions/C_Runtime.spec.lua",
 	"Tests/VectorMath/Matrix3D.spec.lua",
 	"Tests/VectorMath/Matrix4D.spec.lua",
 	"Tests/VectorMath/Vector3D.spec.lua",


### PR DESCRIPTION
Not sure about this, but the idea is to detect test runs in GPU code (to drop WebGPU API calls that won't work in the CI). It's a first step towards adding more testable instrumentation in the renderer.

If this turns out to be useful, it could be moved into the runtime itself, but for the time being it's just an experiment that doesn't warrant a dedicated runtime upgrade.