### PR TITLE
Hide all WebGPU API calls behind facade classes

### DIFF
--- a/Core/NativeClient/WebGPU/BasicTriangleDrawingPipeline.lua
+++ b/Core/NativeClient/WebGPU/BasicTriangleDrawingPipeline.lua
@@ -2,6 +2,8 @@ local bit = require("bit")
 local ffi = require("ffi")
 local webgpu = require("webgpu")
 
+local Device = require("Core.NativeClient.WebGPU.Device")
+
 local binary_not = bit.bnot
 
 local BasicTriangleDrawingPipeline = {
@@ -22,7 +24,7 @@ function BasicTriangleDrawingPipeline:Construct(wgpuDeviceHandle, textureFormatI
 	shaderDesc.nextInChain = shaderCodeDesc.chain
 	shaderCodeDesc.code = shaderSource
 
-	local shaderModule = webgpu.bindings.wgpu_device_create_shader_module(wgpuDeviceHandle, shaderDesc)
+	local shaderModule = Device:CreateShaderModule(wgpuDeviceHandle, shaderDesc)
 
 	-- Configure vertex processing pipeline (vertex fetch/vertex shader stages)
 	local positionAttrib = ffi.new("WGPUVertexAttribute")

--- a/Core/NativeClient/WebGPU/CommandEncoder.lua
+++ b/Core/NativeClient/WebGPU/CommandEncoder.lua
@@ -1,0 +1,17 @@
+local webgpu = require("webgpu")
+
+local CommandEncoder = {}
+
+function CommandEncoder:BeginRenderPass(wgpuCommandEncoder, wgpuRenderPassDescriptor)
+	return webgpu.bindings.wgpu_command_encoder_begin_render_pass(wgpuCommandEncoder, wgpuRenderPassDescriptor)
+end
+
+function CommandEncoder:Finish(wgpuCommandEncoder, wgpuCommandBufferDescriptor)
+	return webgpu.bindings.wgpu_command_encoder_finish(wgpuCommandEncoder, wgpuCommandBufferDescriptor)
+end
+
+CommandEncoder.__call = CommandEncoder.Construct
+CommandEncoder.__index = CommandEncoder
+setmetatable(CommandEncoder, CommandEncoder)
+
+return CommandEncoder

--- a/Core/NativeClient/WebGPU/Device.lua
+++ b/Core/NativeClient/WebGPU/Device.lua
@@ -1,0 +1,33 @@
+local webgpu = require("webgpu")
+
+local Device = {}
+
+function Device:CreateBindGroup(wgpuDevice, wgpuBindGroupDescriptor)
+	return webgpu.bindings.wgpu_device_create_bind_group(wgpuDevice, wgpuBindGroupDescriptor)
+end
+
+function Device:CreateBuffer(wgpuDevice, wgpuBufferDescriptor)
+	return webgpu.bindings.wgpu_device_create_buffer(wgpuDevice, wgpuBufferDescriptor)
+end
+
+function Device:CreateCommandEncoder(wgpuDevice, wgpuCommandEncoderDescriptor)
+	return webgpu.bindings.wgpu_device_create_command_encoder(wgpuDevice, wgpuCommandEncoderDescriptor)
+end
+
+function Device:CreateShaderModule(wgpuDevice, wgpuShaderModuleDescriptor)
+	return webgpu.bindings.wgpu_device_create_shader_module(wgpuDevice, wgpuShaderModuleDescriptor)
+end
+
+function Device:CreateTexture(wgpuDevice, wgpuTextureDescriptor)
+	return webgpu.bindings.wgpu_device_create_texture(wgpuDevice, wgpuTextureDescriptor)
+end
+
+function Device:GetQueue(wgpuDevice)
+	return webgpu.bindings.wgpu_device_get_queue(wgpuDevice)
+end
+
+Device.__call = Device.Construct
+Device.__index = Device
+setmetatable(Device, Device)
+
+return Device

--- a/Core/NativeClient/WebGPU/Queue.lua
+++ b/Core/NativeClient/WebGPU/Queue.lua
@@ -1,0 +1,17 @@
+local webgpu = require("webgpu")
+
+local Queue = {}
+
+function Queue:Submit(wgpuQueue, commandCount, wgpuCommandBuffers)
+	return webgpu.bindings.wgpu_queue_submit(wgpuQueue, commandCount, wgpuCommandBuffers)
+end
+
+function Queue:WriteBuffer(wgpuQueue, wgpuBuffer, bufferOffset, data, size)
+	return webgpu.bindings.wgpu_queue_write_buffer(wgpuQueue, wgpuBuffer, bufferOffset, data, size)
+end
+
+Queue.__call = Queue.Construct
+Queue.__index = Queue
+setmetatable(Queue, Queue)
+
+return Queue

--- a/Core/NativeClient/WebGPU/RenderPassEncoder.lua
+++ b/Core/NativeClient/WebGPU/RenderPassEncoder.lua
@@ -1,0 +1,71 @@
+local webgpu = require("webgpu")
+
+local RenderPassEncoder = {}
+
+function RenderPassEncoder:DrawIndexed(
+	wgpuRenderPassEncoder,
+	indexCount,
+	instanceCount,
+	firstIndex,
+	baseVertex,
+	firstInstance
+)
+	return webgpu.bindings.wgpu_render_pass_encoder_draw_indexed(
+		wgpuRenderPassEncoder,
+		indexCount,
+		instanceCount,
+		firstIndex,
+		baseVertex,
+		firstInstance
+	)
+end
+
+function RenderPassEncoder:End(wgpuRenderPassEncoder)
+	return webgpu.bindings.wgpu_render_pass_encoder_end(wgpuRenderPassEncoder)
+end
+
+function RenderPassEncoder:SetBindGroup(
+	wgpuRenderPassEncoder,
+	groupIndex,
+	wgpuBindGroup,
+	dynamicOffsetCount,
+	dynamicOffsets
+)
+	return webgpu.bindings.wgpu_render_pass_encoder_set_bind_group(
+		wgpuRenderPassEncoder,
+		groupIndex,
+		wgpuBindGroup,
+		dynamicOffsetCount,
+		dynamicOffsets
+	)
+end
+
+function RenderPassEncoder:SetIndexBuffer(wgpuRenderPassEncoder, wgpuBuffer, wgpuIndexFormat, offset, size)
+	return webgpu.bindings.wgpu_render_pass_encoder_set_index_buffer(
+		wgpuRenderPassEncoder,
+		wgpuBuffer,
+		wgpuIndexFormat,
+		offset,
+		size
+	)
+end
+
+function RenderPassEncoder:SetPipeline(wgpuRenderPassEncoder, wgpuRenderPipeline)
+	return webgpu.bindings.wgpu_render_pass_encoder_set_pipeline(wgpuRenderPassEncoder, wgpuRenderPipeline)
+end
+
+function RenderPassEncoder:SetVertexBuffer(wgpuRenderPassEncoder, slot, wgpuBuffer, offset, size)
+	return webgpu.bindings.wgpu_render_pass_encoder_set_vertex_buffer(
+		wgpuRenderPassEncoder,
+		slot,
+		wgpuBuffer,
+		offset,
+		size
+	)
+end
+
+RenderPassEncoder.__call = RenderPassEncoder.Construct
+RenderPassEncoder.__index = RenderPassEncoder
+setmetatable(RenderPassEncoder, RenderPassEncoder)
+
+return RenderPassEncoder

--- a/Core/NativeClient/WebGPU/Texture.lua
+++ b/Core/NativeClient/WebGPU/Texture.lua
@@ -200,6 +200,10 @@ function Texture:GenerateCheckeredGridImage(firstColor, secondColor)
 	return pixels
 end
 
+function Texture:CreateTextureView(wgpuTexture, wgpuTextureViewDescriptor)
+	return webgpu.bindings.wgpu_texture_create_view(wgpuTexture, wgpuTextureViewDescriptor)
+end
+
 Texture.__call = Texture.Construct
 Texture.__index = Texture
 setmetatable(Texture, Texture)


### PR DESCRIPTION
This might seem a bit questionable (and perhaps I'll end up reverting it), but ideally all external API calls would be hidden so that they can be unit tested more freely, where it makes sense.

The facade is a 1:1 mapping to the WebGPU API that currently exposes about 180 functions, a tiny subset of which are actually used by the renderer. That is to say, the maintenance overhead should be negligible as I don't plan to use most of the features.

There may be an opportunity to add event tracing/logging here, too.