### PR TITLE
Add a __len metamethod to the BinaryReader class

### DIFF
--- a/Core/FileFormats/BinaryReader.lua
+++ b/Core/FileFormats/BinaryReader.lua
@@ -160,8 +160,13 @@ function BinaryReader:GetUnsignedInt8()
 	return tonumber(cdataPointer[0])
 end
 
+function BinaryReader:GetBufferSize()
+	return #self.readOnlyBuffer
+end
+
 BinaryReader.__index = BinaryReader
 BinaryReader.__call = BinaryReader.Construct
+BinaryReader.__len = BinaryReader.GetBufferSize
 setmetatable(BinaryReader, BinaryReader)
 
 return BinaryReader

--- a/Tests/FileFormats/BinaryReader.spec.lua
+++ b/Tests/FileFormats/BinaryReader.spec.lua
@@ -43,6 +43,28 @@ describe("BinaryReader", function()
 		end)
 	end)
 
+	describe("GetBufferSize", function()
+		it("should return the byte size of the internal buffer", function()
+			local fileContents = buffer.new(42):put("HELLO")
+			local reader = BinaryReader(fileContents)
+
+			assertEquals(reader:GetBufferSize(), 5)
+			local numBytesRemaining = reader.endOfFilePointer - reader.virtualFilePointer
+			assertEquals(reader:GetBufferSize(), numBytesRemaining)
+		end)
+	end)
+
+	describe("__len", function()
+		it("should return the byte size of the internal buffer", function()
+			local fileContents = buffer.new(42):put("HELLO")
+			local reader = BinaryReader(fileContents)
+
+			assertEquals(#reader, 5)
+			local numBytesRemaining = reader.endOfFilePointer - reader.virtualFilePointer
+			assertEquals(#reader, numBytesRemaining)
+		end)
+	end)
+
 	describe("Forward", function()
 		it("should forward the virtual file pointer if it will stay in the buffered range", function()
 			local fileContents = buffer.new(42):put("He went home and became a family man")


### PR DESCRIPTION
This prevents errors when debugging via lldebug, as it may crash if the metatable doesn't have a length property. Besides that, it's also a convenient shorthand with low maintenance overhead.

Note: `GetBufferSize` is a more readable alias, mostly added for consistency.