### PR TITLE
Consistently apply the official spelling of macOS

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -1,4 +1,4 @@
-name: Build and Release (Mac OS)
+name: Build and Release (macOS)
 
 on:
   push:
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   build:
     if: github.event.pull_request.draft == false
-    name: Build for Mac OS
+    name: Build for macOS
     runs-on: macos-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you want to follow the development more closely, check out the [roadmap](http
 
 Not much to say here; hopefully it'll "just work" on most systems:
 
-* Recent versions of Mac OS, Linux, or Windows
+* Recent versions of macOS, Linux, or Windows
 * Any graphics backend supported by WebGPU (DirectX/Metal/Vulkan)
 * CPU architecture must be supported by the LuaJIT engine
 


### PR DESCRIPTION
Back in my day, it was called "Mac OS X". Apparently, that has changed.