### PR TITLE
Eliminate some redundant WebGPU buffer writes

### DIFF
--- a/Core/NativeClient/Renderer.lua
+++ b/Core/NativeClient/Renderer.lua
@@ -155,16 +155,6 @@ function Renderer:DrawMesh(renderPass, mesh)
 	RenderPassEncoder:SetVertexBuffer(renderPass, 2, mesh.diffuseTexCoordsBuffer, 0, diffuseTexCoordsBufferSize)
 	RenderPassEncoder:SetIndexBuffer(renderPass, mesh.indexBuffer, ffi.C.WGPUIndexFormat_Uint16, 0, indexBufferSize)
 
-	local currentTime = uv.hrtime() / 10E9
-	self.perSceneUniformData.time = currentTime
-	Queue:WriteBuffer(
-		Device:GetQueue(self.wgpuDevice),
-		self.uniformBuffer,
-		0,
-		self.perSceneUniformData,
-		ffi.sizeof(self.perSceneUniformData)
-	)
-
 	RenderPassEncoder:SetBindGroup(renderPass, 0, self.bindGroup, 0, nil)
 
 	if not mesh.texture then


### PR DESCRIPTION
Huh, this doesn't make any sense at all... The scenewide uniform data needs to be updated once per frame, not once per mesh. Perhaps this was supposed to be per-material or even per-mesh data, but I think it's just a copy/paste error.

Caught this thanks to tracing API calls, so `etrace` already paid off... These writes are wasteful and can safely be removed.