### PR TITLE
Add event tracing for some WebGPU API calls

### DIFF
--- a/Core/NativeClient/NativeClient.lua
+++ b/Core/NativeClient/NativeClient.lua
@@ -113,6 +113,7 @@ end
 
 function NativeClient:StartRenderLoop()
 	while glfw.bindings.glfw_window_should_close(self.mainWindow) == 0 do
+		uv.run("nowait")
 		glfw.bindings.glfw_poll_events()
 		self:ProcessWindowEvents()
 		Renderer:RenderNextFrame()

--- a/Core/NativeClient/Renderer.lua
+++ b/Core/NativeClient/Renderer.lua
@@ -1,3 +1,5 @@
+local etrace = require("Core.RuntimeExtensions.etrace")
+
 local bit = require("bit")
 local ffi = require("ffi")
 local uv = require("uv")
@@ -89,6 +91,7 @@ function Renderer:CreatePipelineConfigurations()
 end
 
 function Renderer:RenderNextFrame()
+	etrace.clear()
 	local nextTextureView = self.backingSurface:AcquireTextureView()
 
 	local commandEncoderDescriptor = ffi_new("WGPUCommandEncoderDescriptor")

--- a/Core/NativeClient/WebGPU/Queue.lua
+++ b/Core/NativeClient/WebGPU/Queue.lua
@@ -1,12 +1,18 @@
+local etrace = require("Core.RuntimeExtensions.etrace")
 local webgpu = require("webgpu")
+
+etrace.register("GPU_QUEUE_SUBMIT")
+etrace.register("GPU_BUFFER_WRITE")
 
 local Queue = {}
 
 function Queue:Submit(wgpuQueue, commandCount, wgpuCommandBuffers)
+	etrace.create("GPU_QUEUE_SUBMIT", { commandCount = commandCount })
 	return webgpu.bindings.wgpu_queue_submit(wgpuQueue, commandCount, wgpuCommandBuffers)
 end
 
 function Queue:WriteBuffer(wgpuQueue, wgpuBuffer, bufferOffset, data, size)
+	etrace.create("GPU_BUFFER_WRITE", { bufferOffset = bufferOffset, data = data, size = size })
 	return webgpu.bindings.wgpu_queue_write_buffer(wgpuQueue, wgpuBuffer, bufferOffset, data, size)
 end
 

--- a/start-client.lua
+++ b/start-client.lua
@@ -2,4 +2,16 @@ package.path = "?.lua"
 
 local NativeClient = require("Core.NativeClient.NativeClient")
 
+if arg[1] == "--etrace" then
+	local etrace = require("Core.RuntimeExtensions.etrace")
+	-- The Renderer (and WebGPU modules) have to be loaded prior to this so their events are registered
+	etrace.enable()
+
+	C_Timer.NewTicker(1000, function()
+		-- Dumping traces once per frame isn't currently needed and a little wasteful
+		printf("Dumping traced events for the last rendered frame...")
+		dump(etrace.filter())
+	end)
+end
+
 NativeClient:Start()


### PR DESCRIPTION
This mostly just serves as an example, more traces are to follow. Works with any `wgpu` call, though it may potentially be verbose.