### PR TITLE
Increase the limits of the WebGPU pipeline so that large GND terrain geometry may be rendered

### DIFF
--- a/Core/NativeClient/Renderer.lua
+++ b/Core/NativeClient/Renderer.lua
@@ -149,14 +149,14 @@ end
 function Renderer:DrawMesh(renderPass, mesh)
 	local vertexBufferSize = #mesh.vertexPositions * ffi.sizeof("float")
 	local colorBufferSize = #mesh.vertexColors * ffi.sizeof("float")
-	local indexBufferSize = #mesh.triangleConnections * ffi.sizeof("uint16_t")
+	local indexBufferSize = #mesh.triangleConnections * ffi.sizeof("uint32_t")
 	local diffuseTexCoordsBufferSize = mesh.diffuseTextureCoords and (#mesh.diffuseTextureCoords * ffi.sizeof("float"))
 		or GPU.MAX_VERTEX_COUNT
 
 	RenderPassEncoder:SetVertexBuffer(renderPass, 0, mesh.vertexBuffer, 0, vertexBufferSize)
 	RenderPassEncoder:SetVertexBuffer(renderPass, 1, mesh.colorBuffer, 0, colorBufferSize)
 	RenderPassEncoder:SetVertexBuffer(renderPass, 2, mesh.diffuseTexCoordsBuffer, 0, diffuseTexCoordsBufferSize)
-	RenderPassEncoder:SetIndexBuffer(renderPass, mesh.indexBuffer, ffi.C.WGPUIndexFormat_Uint16, 0, indexBufferSize)
+	RenderPassEncoder:SetIndexBuffer(renderPass, mesh.indexBuffer, ffi.C.WGPUIndexFormat_Uint32, 0, indexBufferSize)
 
 	RenderPassEncoder:SetBindGroup(renderPass, 0, self.bindGroup, 0, nil)
 

--- a/Core/NativeClient/WebGPU/Buffer.lua
+++ b/Core/NativeClient/WebGPU/Buffer.lua
@@ -40,7 +40,7 @@ function Buffer:CreateVertexBuffer(wgpuDevice, entries)
 end
 
 function Buffer:CreateIndexBuffer(wgpuDevice, indices)
-	local rawBufferSizeInBytes = #indices * ffi.sizeof("uint16_t") -- Assumes there won't be too many trianglces per mesh
+	local rawBufferSizeInBytes = #indices * ffi.sizeof("uint32_t") -- Assumes there won't be too many trianglces per mesh
 	local alignedBufferSizeInBytes = Buffer.GetAlignedSize(rawBufferSizeInBytes)
 
 	local bufferDescriptor = ffi.new("WGPUBufferDescriptor")
@@ -53,7 +53,7 @@ function Buffer:CreateIndexBuffer(wgpuDevice, indices)
 		webgpu.bindings.wgpu_device_get_queue(wgpuDevice),
 		buffer,
 		0,
-		ffi.new("uint16_t[?]", alignedBufferSizeInBytes, indices),
+		ffi.new("uint32_t[?]", alignedBufferSizeInBytes, indices),
 		alignedBufferSizeInBytes
 	)
 

--- a/Core/NativeClient/WebGPU/GPU.lua
+++ b/Core/NativeClient/WebGPU/GPU.lua
@@ -3,7 +3,7 @@ local glfw = require("glfw")
 local webgpu = require("webgpu")
 
 local GPU = {
-	MAX_VERTEX_COUNT = 65536, -- Should be configurable (later)
+	MAX_VERTEX_COUNT = 200000, -- Should be configurable (later)
 }
 
 function GPU:CreateInstance()


### PR DESCRIPTION
The largest GND file is `schg_dun01`, so using that as a "worst case scenario" seems like a reasonable choice.

* 16-bit indices are insufficient to render meshes with 80k+ vertices, so let's just use 32-bit (even if it's wasteful for other maps)
* The maximum vertex buffer size also needs increasing as the terrain meshes are HUGE - maybe they could be optimized?

This is split off from the other changes to make sure the GND rendering PR won't be as large as it currently is...