### PR TITLE
Add a way for the WebGPU renderer to load arbitrary texture images (including a somewhat questionable approach to testing)

### DIFF
--- a/Core/NativeClient/Renderer.lua
+++ b/Core/NativeClient/Renderer.lua
@@ -357,6 +357,13 @@ function Renderer:CreateDummyTexture()
 	Renderer:UploadTextureImage(blankTexture)
 end
 
+function Renderer:CreateTextureImage(rgbaImageBytes, width, height)
+	local texture = Texture(self.wgpuDevice, rgbaImageBytes, width, height)
+	Renderer:UploadTextureImage(texture)
+
+	return texture
+end
+
 require("table.new")
 
 function Renderer:CreateDummyTextureCoordinatesBuffer()

--- a/Core/NativeClient/WebGPU/Texture.lua
+++ b/Core/NativeClient/WebGPU/Texture.lua
@@ -92,8 +92,10 @@ function Texture:Construct(wgpuDevice, rgbaImageBytes, textureWidthInPixels, tex
 	-- Depending on the pipeline to be initialized here is unfortunate, but I guess there's no other way?
 	local textureBindGroupDescriptor = ffi.new("WGPUBindGroupDescriptor")
 	textureBindGroupDescriptor.layout = BasicTriangleDrawingPipeline.wgpuMaterialBindGroupLayout
-	textureBindGroupDescriptor.entryCount =
-		BasicTriangleDrawingPipeline.wgpuMaterialBindGroupLayoutDescriptor.entryCount
+
+	local wgpuMaterialBindGroupLayoutDescriptor = BasicTriangleDrawingPipeline.wgpuMaterialBindGroupLayoutDescriptor
+		or select(2, BasicTriangleDrawingPipeline:CreateMaterialBindGroupLayout(wgpuDevice))
+	textureBindGroupDescriptor.entryCount = wgpuMaterialBindGroupLayoutDescriptor.entryCount
 	textureBindGroupDescriptor.entries = bindGroupEntries
 
 	local bindGroup = webgpu.bindings.wgpu_device_create_bind_group(wgpuDevice, textureBindGroupDescriptor)

--- a/Core/NativeClient/WebGPU/VirtualGPU.lua
+++ b/Core/NativeClient/WebGPU/VirtualGPU.lua
@@ -1,0 +1,49 @@
+local etrace = require("Core.RuntimeExtensions.etrace")
+local ffi = require("ffi")
+local webgpu = require("webgpu")
+
+local VirtualGPU = {
+	events = {
+		GPU_TEXTURE_WRITE = true,
+	},
+	virtualizedBindings = {
+		wgpu_device_create_sampler = function(...) end,
+		wgpu_device_create_texture = function(...)
+			return ffi.new("WGPUTexture")
+		end,
+		wgpu_texture_create_view = function(...) end,
+		wgpu_device_create_bind_group_layout = function(...) end,
+		wgpu_device_create_bind_group = function(...) end,
+		wgpu_device_get_queue = function(...)
+			return ffi.new("WGPUQueue")
+		end,
+		wgpu_queue_write_texture = function(queue, destination, data, dataSize, dataLayout, writeSize)
+			etrace.create("GPU_TEXTURE_WRITE", {
+				destination = destination,
+				data = data,
+				dataSize = dataSize,
+				dataLayout = dataLayout,
+				writeSize = writeSize,
+			})
+		end,
+	},
+}
+
+function VirtualGPU:Enable()
+	for event, _ in pairs(self.events) do
+		etrace.register(event)
+	end
+
+	self.backedUpBindings = webgpu.bindings
+	webgpu.bindings = self.virtualizedBindings
+end
+
+function VirtualGPU:Disable()
+	for event, isEnabled in pairs(self.events) do
+		etrace.unregister(event)
+	end
+
+	webgpu.bindings = self.backedUpBindings
+end
+
+return VirtualGPU

--- a/Tests/NativeClient/Renderer.spec.lua
+++ b/Tests/NativeClient/Renderer.spec.lua
@@ -1,0 +1,44 @@
+local etrace = require("Core.RuntimeExtensions.etrace")
+local ffi = require("ffi")
+
+local Renderer = require("Core.NativeClient.Renderer")
+local VirtualGPU = require("Core.NativeClient.WebGPU.VirtualGPU")
+
+describe("Renderer", function()
+	-- The renderer wasn't designed to be testable, so a few hacks are currently required...
+	Renderer.wgpuDevice = ffi.new("WGPUDevice")
+
+	before(function()
+		VirtualGPU:Enable()
+		etrace.enable("GPU_TEXTURE_WRITE")
+	end)
+
+	after(function()
+		etrace.disable("GPU_TEXTURE_WRITE")
+		VirtualGPU:Disable()
+	end)
+
+	describe("CreateTextureImage", function()
+		it("should upload the image data to the GPU", function()
+			local rgbaImageBytes, width, height = string.rep("\255\0\0\255", 256 * 256), 256, 256
+
+			Renderer:CreateTextureImage(rgbaImageBytes, width, height)
+
+			local events = etrace.filter("GPU_TEXTURE_WRITE")
+			local payload = events[1].payload
+
+			assertEquals(events[1].name, "GPU_TEXTURE_WRITE")
+			assertEquals(payload.dataSize, width * height * 4)
+			assertEquals(payload.writeSize.width, width)
+			assertEquals(payload.writeSize.height, height)
+			assertEquals(payload.writeSize.depthOrArrayLayers, 1)
+
+			assertEquals(#payload.data, #rgbaImageBytes) -- More readable errors in case of failure
+			assertEquals(payload.data, rgbaImageBytes)
+
+			assertEquals(tonumber(events[1].payload.dataLayout.offset), 0)
+			assertEquals(tonumber(events[1].payload.dataLayout.bytesPerRow), width * 4)
+			assertEquals(tonumber(events[1].payload.dataLayout.rowsPerImage), height)
+		end)
+	end)
+end)

--- a/Tests/unit-test.lua
+++ b/Tests/unit-test.lua
@@ -23,6 +23,7 @@ local specFiles = {
 	"Tests/NativeClient/C_Camera.spec.lua",
 	"Tests/NativeClient/C_Cursor.spec.lua",
 	"Tests/NativeClient/NativeClient.spec.lua",
+	"Tests/NativeClient/Renderer.spec.lua",
 	"Tests/NativeClient/DebugDraw/Box.spec.lua",
 	"Tests/NativeClient/DebugDraw/Cone.spec.lua",
 	"Tests/NativeClient/DebugDraw/Cylinder.spec.lua",


### PR DESCRIPTION
Trivial addition, but perhaps more interesting: An experimental "virtual GPU" to allow unit testing in the absence of GPU runners.

I still have to look into running fully-featured tests, at least on Windows, but lacking that at least the WebGPU calls can be traced.