### PR TITLE
Add unit tests for the WebGPU renderer's geometry transferral APIs

### DIFF
--- a/Core/NativeClient/Renderer.lua
+++ b/Core/NativeClient/Renderer.lua
@@ -241,6 +241,22 @@ function Renderer:UploadMeshGeometry(mesh)
 	table.insert(self.meshes, mesh)
 end
 
+function Renderer:DestroyMeshGeometry(mesh)
+	Buffer:Destroy(mesh.vertexBuffer)
+	Buffer:Destroy(mesh.colorBuffer)
+	Buffer:Destroy(mesh.indexBuffer)
+	if mesh.diffuseTexCoordsBuffer ~= self.dummyTexCoordsBuffer then
+		-- Don't destroy this, it might still be used by other meshes
+		Buffer:Destroy(mesh.diffuseTexCoordsBuffer)
+	end
+
+	for index, value in pairs(self.meshes) do
+		if value == mesh then
+			table.remove(self.meshes, index)
+		end
+	end
+end
+
 function Renderer:UploadTextureImage(texture)
 	if not texture then
 		return

--- a/Core/NativeClient/WebGPU/Buffer.lua
+++ b/Core/NativeClient/WebGPU/Buffer.lua
@@ -2,7 +2,10 @@ local bit = require("bit")
 local ffi = require("ffi")
 local webgpu = require("webgpu")
 
-local Buffer = {}
+local Buffer = {
+	VERTEX_BUFFER_FLAGS = bit.bor(ffi.C.WGPUBufferUsage_CopyDst, ffi.C.WGPUBufferUsage_Vertex),
+	INDEX_BUFFER_FLAGS = bit.bor(ffi.C.WGPUBufferUsage_CopyDst, ffi.C.WGPUBufferUsage_Index),
+}
 
 local ALIGNMENT_IN_BYTES = 4
 
@@ -24,7 +27,7 @@ function Buffer:CreateVertexBuffer(wgpuDevice, entries)
 
 	local bufferDescriptor = ffi.new("WGPUBufferDescriptor")
 	bufferDescriptor.size = alignedBufferSizeInBytes
-	bufferDescriptor.usage = bit.bor(ffi.C.WGPUBufferUsage_CopyDst, ffi.C.WGPUBufferUsage_Vertex)
+	bufferDescriptor.usage = Buffer.VERTEX_BUFFER_FLAGS
 	bufferDescriptor.mappedAtCreation = false
 
 	local buffer = webgpu.bindings.wgpu_device_create_buffer(wgpuDevice, bufferDescriptor)
@@ -45,7 +48,7 @@ function Buffer:CreateIndexBuffer(wgpuDevice, indices)
 
 	local bufferDescriptor = ffi.new("WGPUBufferDescriptor")
 	bufferDescriptor.size = alignedBufferSizeInBytes
-	bufferDescriptor.usage = bit.bor(ffi.C.WGPUBufferUsage_CopyDst, ffi.C.WGPUBufferUsage_Index)
+	bufferDescriptor.usage = Buffer.INDEX_BUFFER_FLAGS
 	bufferDescriptor.mappedAtCreation = false
 
 	local buffer = webgpu.bindings.wgpu_device_create_buffer(wgpuDevice, bufferDescriptor)

--- a/Core/NativeClient/WebGPU/Buffer.lua
+++ b/Core/NativeClient/WebGPU/Buffer.lua
@@ -60,4 +60,8 @@ function Buffer:CreateIndexBuffer(wgpuDevice, indices)
 	return buffer
 end
 
+function Buffer:Destroy(wgpuBuffer)
+	webgpu.bindings.wgpu_buffer_destroy(wgpuBuffer)
+end
+
 return Buffer

--- a/Core/NativeClient/WebGPU/Queue.lua
+++ b/Core/NativeClient/WebGPU/Queue.lua
@@ -1,18 +1,12 @@
-local etrace = require("Core.RuntimeExtensions.etrace")
 local webgpu = require("webgpu")
-
-etrace.register("GPU_QUEUE_SUBMIT")
-etrace.register("GPU_BUFFER_WRITE")
 
 local Queue = {}
 
 function Queue:Submit(wgpuQueue, commandCount, wgpuCommandBuffers)
-	etrace.create("GPU_QUEUE_SUBMIT", { commandCount = commandCount })
 	return webgpu.bindings.wgpu_queue_submit(wgpuQueue, commandCount, wgpuCommandBuffers)
 end
 
 function Queue:WriteBuffer(wgpuQueue, wgpuBuffer, bufferOffset, data, size)
-	etrace.create("GPU_BUFFER_WRITE", { bufferOffset = bufferOffset, data = data, size = size })
 	return webgpu.bindings.wgpu_queue_write_buffer(wgpuQueue, wgpuBuffer, bufferOffset, data, size)
 end
 

--- a/Core/NativeClient/WebGPU/VirtualGPU.lua
+++ b/Core/NativeClient/WebGPU/VirtualGPU.lua
@@ -54,6 +54,7 @@ function VirtualGPU:Disable()
 	end
 
 	webgpu.bindings = self.backedUpBindings
+	self.backedUpBindings = nil
 
 	etrace.disable()
 end

--- a/Core/NativeClient/WebGPU/VirtualGPU.lua
+++ b/Core/NativeClient/WebGPU/VirtualGPU.lua
@@ -4,6 +4,9 @@ local webgpu = require("webgpu")
 
 local VirtualGPU = {
 	events = {
+		GPU_BUFFER_CREATE = true,
+		GPU_BUFFER_DESTROY = true,
+		GPU_BUFFER_WRITE = true,
 		GPU_TEXTURE_WRITE = true,
 	},
 	virtualizedBindings = {
@@ -24,6 +27,26 @@ local VirtualGPU = {
 				dataSize = dataSize,
 				dataLayout = dataLayout,
 				writeSize = writeSize,
+			})
+		end,
+		wgpu_device_create_buffer = function(device, descriptor)
+			etrace.create("GPU_BUFFER_CREATE", {
+				device = device,
+				descriptor = descriptor,
+			})
+		end,
+		wgpu_queue_write_buffer = function(queue, buffer, bufferOffset, data, size)
+			etrace.create("GPU_BUFFER_WRITE", {
+				queue = queue,
+				buffer = buffer,
+				bufferOffset = bufferOffset,
+				data = data,
+				size = size,
+			})
+		end,
+		wgpu_buffer_destroy = function(buffer)
+			etrace.create("GPU_BUFFER_DESTROY", {
+				buffer = buffer,
 			})
 		end,
 	},

--- a/Core/NativeClient/WebGPU/VirtualGPU.lua
+++ b/Core/NativeClient/WebGPU/VirtualGPU.lua
@@ -29,7 +29,14 @@ local VirtualGPU = {
 	},
 }
 
+setmetatable(VirtualGPU.virtualizedBindings, {
+	__index = function(t, k)
+		error(format("NYI: Virtualized binding is missing for %s", k), 0)
+	end,
+})
+
 function VirtualGPU:Enable()
+	printf("[VirtualGPU] WebGPU call interception is now ON")
 	for event, _ in pairs(self.events) do
 		etrace.register(event)
 	end
@@ -41,6 +48,7 @@ function VirtualGPU:Enable()
 end
 
 function VirtualGPU:Disable()
+	printf("[VirtualGPU] WebGPU call interception is now OFF")
 	for event, isEnabled in pairs(self.events) do
 		etrace.unregister(event)
 	end

--- a/Core/NativeClient/WebGPU/VirtualGPU.lua
+++ b/Core/NativeClient/WebGPU/VirtualGPU.lua
@@ -36,6 +36,8 @@ function VirtualGPU:Enable()
 
 	self.backedUpBindings = webgpu.bindings
 	webgpu.bindings = self.virtualizedBindings
+
+	etrace.enable()
 end
 
 function VirtualGPU:Disable()
@@ -44,6 +46,8 @@ function VirtualGPU:Disable()
 	end
 
 	webgpu.bindings = self.backedUpBindings
+
+	etrace.disable()
 end
 
 return VirtualGPU

--- a/Core/RuntimeExtensions/etrace.lua
+++ b/Core/RuntimeExtensions/etrace.lua
@@ -6,6 +6,21 @@ local type = type
 local format = string.format
 local table_insert = table.insert
 
+local table_copy
+table_copy = function(source)
+	local deepCopy = {}
+
+	for key, value in pairs(source) do
+		if type(value) == "table" then
+			deepCopy[key] = table.copy(value)
+		else
+			deepCopy[key] = value
+		end
+	end
+
+	return deepCopy
+end
+
 local etrace = {
 	registeredEvents = {},
 	eventLog = {},
@@ -145,8 +160,8 @@ end
 
 function etrace.filter(event)
 	if event == nil or (type(event) == "table" and #event == 0) then
-		-- This better not be modified from outside (avoids a deep copy)
-		return etrace.eventLog
+		-- This may be modified if other events are created
+		return table_copy(etrace.eventLog)
 	end
 
 	local events = {}

--- a/Core/RuntimeExtensions/etrace.lua
+++ b/Core/RuntimeExtensions/etrace.lua
@@ -12,7 +12,7 @@ table_copy = function(source)
 
 	for key, value in pairs(source) do
 		if type(value) == "table" then
-			deepCopy[key] = table.copy(value)
+			deepCopy[key] = table_copy(value)
 		else
 			deepCopy[key] = value
 		end

--- a/Tests/NativeClient/Renderer.spec.lua
+++ b/Tests/NativeClient/Renderer.spec.lua
@@ -2,21 +2,11 @@ local etrace = require("Core.RuntimeExtensions.etrace")
 local ffi = require("ffi")
 
 local Renderer = require("Core.NativeClient.Renderer")
-local VirtualGPU = require("Core.NativeClient.WebGPU.VirtualGPU")
 
 describe("Renderer", function()
 	-- The renderer wasn't designed to be testable, so a few hacks are currently required...
 	Renderer.wgpuDevice = ffi.new("WGPUDevice")
-
-	before(function()
-		VirtualGPU:Enable()
-		etrace.enable("GPU_TEXTURE_WRITE")
-	end)
-
-	after(function()
-		etrace.disable("GPU_TEXTURE_WRITE")
-		VirtualGPU:Disable()
-	end)
+	-- Should use beforeEach/afterEach to set up and tear down the VirtualGPU here
 
 	describe("CreateTextureImage", function()
 		it("should upload the image data to the GPU", function()

--- a/Tests/NativeClient/Renderer.spec.lua
+++ b/Tests/NativeClient/Renderer.spec.lua
@@ -1,13 +1,26 @@
 local etrace = require("Core.RuntimeExtensions.etrace")
 local ffi = require("ffi")
 
+local Plane = require("Core.NativeClient.DebugDraw.Plane")
 local Renderer = require("Core.NativeClient.Renderer")
 
-describe("Renderer", function()
-	-- The renderer wasn't designed to be testable, so a few hacks are currently required...
-	Renderer.wgpuDevice = ffi.new("WGPUDevice")
-	-- Should use beforeEach/afterEach to set up and tear down the VirtualGPU here
+local Buffer = require("Core.NativeClient.WebGPU.Buffer")
+local VirtualGPU = require("Core.NativeClient.WebGPU.VirtualGPU")
 
+local planeMesh = Plane()
+
+local function assertEqualArrayContents(arrayBuffer, arrayTable)
+	for index = 0, #arrayTable - 1, 1 do
+		-- Assumes no read-fault will occur (OOB array access) because geometry is stored in tables
+		-- Also assumes the cdata arrays will be of the right type (i.e., float/uint32 and not uint8)
+		assertEquals(arrayTable[index + 1], arrayBuffer[index])
+	end
+end
+
+VirtualGPU:Enable()
+-- The renderer wasn't designed to be testable, so a few hacks are currently required...
+Renderer.wgpuDevice = ffi.new("WGPUDevice")
+describe("Renderer", function()
 	describe("CreateTextureImage", function()
 		it("should upload the image data to the GPU", function()
 			local rgbaImageBytes, width, height = string.rep("\255\0\0\255", 256 * 256), 256, 256
@@ -31,4 +44,116 @@ describe("Renderer", function()
 			assertEquals(tonumber(events[1].payload.dataLayout.rowsPerImage), height)
 		end)
 	end)
+
+	describe("UploadMeshGeometry", function()
+		after(function()
+			for index, mesh in ipairs(Renderer.meshes) do
+				Renderer:DestroyMeshGeometry(mesh)
+			end
+			etrace.clear() -- Remove all the WebGPU calls
+		end)
+
+		it("should add the given mesh to to the list of scene objects to be rendered each frame", function()
+			Renderer:UploadMeshGeometry(planeMesh)
+			assertEquals(#Renderer.meshes, 1)
+			assertEquals(Renderer.meshes[1], planeMesh)
+		end)
+
+		it("should upload the mesh's geometry buffers to the GPU", function()
+			Renderer:UploadMeshGeometry(planeMesh)
+			local events = etrace.filter()
+
+			Renderer:DestroyMeshGeometry(planeMesh)
+
+			assertEquals(#events, 8)
+
+			-- Vertex positions
+			local index = 1
+			local expectedBufferSize = Buffer.GetAlignedSize(#planeMesh.vertexPositions * ffi.sizeof("float"))
+			assertEquals(events[index].name, "GPU_BUFFER_CREATE")
+			assertEquals(events[index].payload.descriptor.usage, Buffer.VERTEX_BUFFER_FLAGS)
+			assertEquals(tonumber(events[index].payload.descriptor.size), expectedBufferSize)
+			assertEquals(events[index].payload.descriptor.mappedAtCreation ~= 0, false)
+
+			index = index + 1
+			assertEquals(events[index].name, "GPU_BUFFER_WRITE")
+			assertEquals(events[index].payload.bufferOffset, 0)
+			assertEquals(ffi.sizeof(events[index].payload.data), expectedBufferSize * ffi.sizeof("float"))
+			assertEquals(events[index].payload.size, expectedBufferSize)
+			assertEqualArrayContents(events[index].payload.data, planeMesh.vertexPositions)
+
+			-- Vertex colors
+			index = index + 1
+			expectedBufferSize = Buffer.GetAlignedSize(#planeMesh.vertexColors * ffi.sizeof("float"))
+			assertEquals(events[index].name, "GPU_BUFFER_CREATE")
+			assertEquals(events[index].payload.descriptor.usage, Buffer.VERTEX_BUFFER_FLAGS)
+			assertEquals(tonumber(events[index].payload.descriptor.size), expectedBufferSize)
+			assertEquals(events[index].payload.descriptor.mappedAtCreation ~= 0, false)
+
+			index = index + 1
+			assertEquals(events[index].name, "GPU_BUFFER_WRITE")
+			assertEquals(events[index].payload.bufferOffset, 0)
+			assertEquals(ffi.sizeof(events[index].payload.data), expectedBufferSize * ffi.sizeof("float"))
+			assertEquals(events[index].payload.size, expectedBufferSize)
+			assertEqualArrayContents(events[index].payload.data, planeMesh.vertexColors)
+
+			-- Index buffer
+			index = index + 1
+			expectedBufferSize = Buffer.GetAlignedSize(#planeMesh.triangleConnections * ffi.sizeof("uint32_t"))
+			assertEquals(events[index].name, "GPU_BUFFER_CREATE")
+			assertEquals(events[index].payload.descriptor.usage, Buffer.INDEX_BUFFER_FLAGS)
+			assertEquals(tonumber(events[index].payload.descriptor.size), expectedBufferSize)
+			assertEquals(events[index].payload.descriptor.mappedAtCreation ~= 0, false)
+
+			index = index + 1
+			assertEquals(events[index].name, "GPU_BUFFER_WRITE")
+			assertEquals(events[index].payload.bufferOffset, 0)
+			assertEquals(ffi.sizeof(events[index].payload.data), expectedBufferSize * ffi.sizeof("uint32_t"))
+			assertEquals(events[index].payload.size, expectedBufferSize)
+			assertEqualArrayContents(events[index].payload.data, planeMesh.triangleConnections)
+
+			-- Diffuse texture coordinates
+			index = index + 1
+			expectedBufferSize = Buffer.GetAlignedSize(#planeMesh.diffuseTextureCoords * ffi.sizeof("float"))
+			assertEquals(events[index].name, "GPU_BUFFER_CREATE")
+			assertEquals(events[index].payload.descriptor.usage, Buffer.VERTEX_BUFFER_FLAGS)
+			assertEquals(tonumber(events[index].payload.descriptor.size), expectedBufferSize)
+			assertEquals(events[index].payload.descriptor.mappedAtCreation ~= 0, false)
+
+			index = index + 1
+			assertEquals(events[index].name, "GPU_BUFFER_WRITE")
+			assertEquals(events[index].payload.bufferOffset, 0)
+			assertEquals(ffi.sizeof(events[index].payload.data), expectedBufferSize * ffi.sizeof("float"))
+			assertEquals(events[index].payload.size, expectedBufferSize)
+			assertEqualArrayContents(events[index].payload.data, planeMesh.diffuseTextureCoords)
+		end)
+	end)
+
+	describe("DestroyMeshGeometry", function()
+		before(function()
+			Renderer:UploadMeshGeometry(planeMesh)
+			etrace.clear()
+		end)
+
+		it("should remove the given mesh from the list of scene events to be rendered each frame", function()
+			Renderer:DestroyMeshGeometry(planeMesh)
+			assertEquals(#Renderer.meshes, 0)
+			assertEquals(Renderer.meshes, {})
+		end)
+
+		it("should destroy any uniquely-allocated buffers assigned to the mesh", function()
+			Renderer:DestroyMeshGeometry(planeMesh)
+			local events = etrace.filter()
+
+			assertEquals(#events, 3)
+
+			-- It's technically possible that the wrong buffers are destroyed here, but eh...
+			assertEquals(events[1].name, "GPU_BUFFER_DESTROY")
+			assertEquals(events[2].name, "GPU_BUFFER_DESTROY")
+			assertEquals(events[3].name, "GPU_BUFFER_DESTROY")
+			-- Default texture coordinates shouldn't be destroyed (implicit)
+		end)
+	end)
 end)
+
+VirtualGPU:Disable()

--- a/Tests/RuntimeExtensions/etrace.spec.lua
+++ b/Tests/RuntimeExtensions/etrace.spec.lua
@@ -472,5 +472,28 @@ describe("etrace", function()
 			assertEquals(eventLog[2], expectedEventLog[2])
 			assertEquals(eventLog[3], expectedEventLog[3])
 		end)
+
+		it("should return a copy of the list and not a reference that can change after the fact", function()
+			etrace.register("SOME_EVENT")
+			etrace.register("ANOTHER_EVENT")
+			etrace.enable("SOME_EVENT")
+			etrace.enable("ANOTHER_EVENT")
+
+			etrace.create("SOME_EVENT")
+			local eventLog = etrace.filter()
+			local expectedEventLog = {
+				{ name = "SOME_EVENT", payload = {} },
+			}
+
+			-- So far, so good...
+			assertEquals(#eventLog, #expectedEventLog)
+			assertEquals(eventLog[1], expectedEventLog[1])
+
+			etrace.create("ANOTHER_EVENT")
+
+			-- If a copy of the internal event log is returned, more events can be added after the fact
+			assertEquals(#eventLog, #expectedEventLog)
+			assertEquals(eventLog[1], expectedEventLog[1])
+		end)
 	end)
 end)

--- a/Tests/unit-test.lua
+++ b/Tests/unit-test.lua
@@ -37,6 +37,10 @@ local specFiles = {
 	"Tests/Tools/RagnarokTools.spec.lua",
 }
 
+-- The test runner currently doesn't support "before-each" and "after-each"; remove this hack later
+local VirtualGPU = require("Core.NativeClient.WebGPU.VirtualGPU")
+VirtualGPU:Enable()
 local numFailedSections = C_Runtime.RunDetailedTests(#arg > 0 and arg or specFiles)
+VirtualGPU:Disable()
 
 os.exit(numFailedSections)

--- a/Tests/unit-test.lua
+++ b/Tests/unit-test.lua
@@ -37,10 +37,6 @@ local specFiles = {
 	"Tests/Tools/RagnarokTools.spec.lua",
 }
 
--- The test runner currently doesn't support "before-each" and "after-each"; remove this hack later
-local VirtualGPU = require("Core.NativeClient.WebGPU.VirtualGPU")
-VirtualGPU:Enable()
 local numFailedSections = C_Runtime.RunDetailedTests(#arg > 0 and arg or specFiles)
-VirtualGPU:Disable()
 
 os.exit(numFailedSections)


### PR DESCRIPTION
They're still quite messy and not sure I like the call interception approach, but for now it'll have to do.

Oh, and I guess `DestroyMeshGeometry` is technically "new" since it wasn't merged into the `main` branch yet...