### PR TITLE
Implement a preprocessing step for diffuse textures that discards the magenta background pixels

### DIFF
--- a/Core/NativeClient/Renderer.lua
+++ b/Core/NativeClient/Renderer.lua
@@ -24,6 +24,7 @@ local assert = assert
 local ipairs = ipairs
 
 local ffi_new = ffi.new
+local format = string.format
 local filesize = string.filesize
 
 local Color = require("Core.NativeClient.DebugDraw.Color")
@@ -44,6 +45,7 @@ local Renderer = {
 	clearColorRGBA = { Color.GREY.red, Color.GREY.green, Color.GREY.blue, 0 },
 	renderPipelines = {},
 	meshes = {},
+	DEBUG_DISCARDED_BACKGROUND_PIXELS = false, -- This is really slow (disk I/O); don't enable unless necessary
 }
 
 ffi.cdef(Renderer.cdefs)
@@ -162,11 +164,11 @@ function Renderer:DrawMesh(renderPass, mesh)
 
 	RenderPassEncoder:SetBindGroup(renderPass, 0, self.bindGroup, 0, nil)
 
-	if not mesh.texture then
+	if not mesh.diffuseTexture then
 		-- The pipeline layout is kept identical (for simplicity's sake... ironic, considering how complicated this already is)
 		RenderPassEncoder:SetBindGroup(renderPass, 1, self.dummyTexture.wgpuBindGroup, 0, nil)
 	else
-		RenderPassEncoder:SetBindGroup(renderPass, 1, mesh.texture.wgpuBindGroup, 0, nil)
+		RenderPassEncoder:SetBindGroup(renderPass, 1, mesh.diffuseTexture.wgpuBindGroup, 0, nil)
 	end
 
 	local instanceCount = 1
@@ -369,7 +371,54 @@ function Renderer:CreateDummyTexture()
 	Renderer:UploadTextureImage(blankTexture)
 end
 
+-- Should probably move this to the runtime for efficiency (needs benchmarking)
+-- Also... should use string buffers everywhere, but currently the API still uses strings
+local function discardTransparentPixels(rgbaImageBytes, width, height, discardRanges)
+	local OFFSET_RED = 0
+	local OFFSET_GREEN = 1
+	local OFFSET_BLUE = 2
+	local OFFSET_ALPHA = 3
+
+	local DISCARD_MIN_RED = discardRanges.red.from
+	local DISCARD_MAX_RED = discardRanges.red.to
+	local DISCARD_MIN_GREEN = discardRanges.green.from
+	local DISCARD_MAX_GREEN = discardRanges.green.to
+	local DISCARD_MIN_BLUE = discardRanges.blue.from
+	local DISCARD_MAX_BLUE = discardRanges.blue.to
+
+	local rgbaImageBuffer = buffer.new(width * height * 4):put(rgbaImageBytes)
+	local pixelArray, bufferSize = rgbaImageBuffer:ref()
+	assert(bufferSize == width * height * 4)
+
+	for pixelStartOffset = 0, width * height * 4, 4 do
+		local red = pixelArray[pixelStartOffset + OFFSET_RED]
+		local green = pixelArray[pixelStartOffset + OFFSET_GREEN]
+		local blue = pixelArray[pixelStartOffset + OFFSET_BLUE]
+
+		local isRedWithinDiscardedRange = (red >= DISCARD_MIN_RED and red <= DISCARD_MAX_RED)
+		local isGreenWithinDiscardedRange = (green >= DISCARD_MIN_GREEN and green <= DISCARD_MAX_GREEN)
+		local isBlueWithinDiscardedRange = (blue >= DISCARD_MIN_BLUE and blue <= DISCARD_MAX_BLUE)
+		local shouldDiscardPixel = isRedWithinDiscardedRange
+			and isGreenWithinDiscardedRange
+			and isBlueWithinDiscardedRange
+
+		if shouldDiscardPixel then
+			pixelArray[pixelStartOffset + OFFSET_ALPHA] = 0
+		end
+	end
+
+	return rgbaImageBuffer:tostring()
+end
+
 function Renderer:CreateTextureImage(rgbaImageBytes, width, height)
+	local inclusiveTransparentPixelRanges = {
+		red = { from = 254, to = 255 },
+		green = { from = 0, to = 3 },
+		blue = { from = 254, to = 255 },
+	}
+	-- This is currently NOT in-place and so incurs unnecessary copy overhead (optimize later)
+	rgbaImageBytes = discardTransparentPixels(rgbaImageBytes, width, height, inclusiveTransparentPixelRanges)
+
 	local texture = Texture(self.wgpuDevice, rgbaImageBytes, width, height)
 	Renderer:UploadTextureImage(texture)
 
@@ -394,15 +443,36 @@ function Renderer:LoadSceneObjects(scene)
 		self:UploadMeshGeometry(mesh)
 
 		if mesh.diffuseTexture then
-			local diffuseTexture = self:CreateTextureImage(
+			self:DebugDumpTextures(mesh, format("diffuse-texture-%s-%03d-in.png", scene.mapID, index))
+			mesh.diffuseTexture = self:CreateTextureImage(
 				mesh.diffuseTexture.rgbaImageBytes,
 				mesh.diffuseTexture.width,
 				mesh.diffuseTexture.height
 			)
-			mesh.texture = diffuseTexture
-			self:UploadTextureImage(mesh.texture)
+			self:DebugDumpTextures(mesh, format("diffuse-texture-%s-%03d-out.png", scene.mapID, index))
+			self:UploadTextureImage(mesh.diffuseTexture)
 		end
 	end
+end
+
+function Renderer:DebugDumpTextures(mesh, fileName)
+	if not Renderer.DEBUG_DISCARDED_BACKGROUND_PIXELS then
+		return
+	end
+
+	if not mesh then
+		return
+	end
+
+	local diffuseTexture = mesh.diffuseTexture
+	if not diffuseTexture then
+		return
+	end
+
+	C_FileSystem.MakeDirectoryTree("Exports")
+	local pngBytes =
+		C_ImageProcessing.EncodePNG(diffuseTexture.rgbaImageBytes, diffuseTexture.width, diffuseTexture.height)
+	C_FileSystem.WriteFile(path.join("Exports", fileName), pngBytes)
 end
 
 function Renderer:ResetScene()

--- a/Core/NativeClient/Shaders/BasicTriangleShader.wgsl
+++ b/Core/NativeClient/Shaders/BasicTriangleShader.wgsl
@@ -26,6 +26,7 @@ struct VertexOutput {
 };
 
 const MATH_PI = 3.14159266;
+const DEBUG_ALPHA_OFFSET = 0.0; // Set to non-zero value (e.g., 0.2) to make transparent background pixels visible
 
 fn deg2rad(angleInDegrees: f32) -> f32 {
     return angleInDegrees * MATH_PI / 180.0;
@@ -106,5 +107,5 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
     // When setting the surface format to BGRA8UnormSrgb it performs a linear to sRGB conversion.
     // Gamma-correction
     let corrected_color = pow(finalColor.rgb, vec3f(2.2));
-    return vec4f(corrected_color, uPerSceneData.color.a);
+    return vec4f(corrected_color, uPerSceneData.color.a * diffuseTextureColor.a + DEBUG_ALPHA_OFFSET);
 }

--- a/Tests/NativeClient/Renderer.spec.lua
+++ b/Tests/NativeClient/Renderer.spec.lua
@@ -1,5 +1,6 @@
 local etrace = require("etrace")
 local ffi = require("ffi")
+local miniz = require("miniz")
 
 local Plane = require("Core.NativeClient.DebugDraw.Plane")
 local Renderer = require("Core.NativeClient.Renderer")
@@ -22,6 +23,10 @@ VirtualGPU:Enable()
 Renderer.wgpuDevice = ffi.new("WGPUDevice")
 describe("Renderer", function()
 	describe("CreateTextureImage", function()
+		before(function()
+			etrace.clear() -- Discard submitted textures in between tests
+		end)
+
 		it("should upload the image data to the GPU", function()
 			local rgbaImageBytes, width, height = string.rep("\255\0\0\255", 256 * 256), 256, 256
 
@@ -42,6 +47,100 @@ describe("Renderer", function()
 			assertEquals(tonumber(events[1].payload.dataLayout.offset), 0)
 			assertEquals(tonumber(events[1].payload.dataLayout.bytesPerRow), width * 4)
 			assertEquals(tonumber(events[1].payload.dataLayout.rowsPerImage), height)
+		end)
+
+		it("should discard transparent background pixels in the final image", function()
+			local IMAGE_WIDTH, IMAGE_HEIGHT = 256, 256
+			local transparentColors = {
+				"\254\000\254\255",
+				"\254\000\255\255",
+				"\254\001\254\255",
+				"\254\001\255\255",
+				"\254\002\254\255",
+				"\254\002\255\255",
+				"\254\003\254\255",
+				"\254\003\255\255",
+				"\255\000\254\255",
+				"\255\000\255\255",
+				"\255\001\254\255",
+				"\255\001\255\255",
+				"\255\002\254\255",
+				"\255\002\255\255",
+				"\255\003\254\255",
+				"\255\003\255\255",
+			}
+
+			local function createImageBytes(pixel)
+				return string.rep(pixel, IMAGE_WIDTH * IMAGE_HEIGHT)
+			end
+
+			local transparentImages = {}
+			for index = 1, #transparentColors, 1 do
+				table.insert(transparentImages, createImageBytes(transparentColors[index]))
+			end
+
+			-- Only discard alpha to save on unnecessary writes
+			local expectedPixelValues = {
+				"\254\000\254\000",
+				"\254\000\255\000",
+				"\254\001\254\000",
+				"\254\001\255\000",
+				"\254\002\254\000",
+				"\254\002\255\000",
+				"\254\003\254\000",
+				"\254\003\255\000",
+				"\255\000\254\000",
+				"\255\000\255\000",
+				"\255\001\254\000",
+				"\255\001\255\000",
+				"\255\002\254\000",
+				"\255\002\255\000",
+				"\255\003\254\000",
+				"\255\003\255\000",
+			}
+
+			local expectedImages = {}
+			for index = 1, #expectedPixelValues, 1 do
+				table.insert(expectedImages, createImageBytes(expectedPixelValues[index]))
+			end
+
+			local function assertRendererDiscardsTransparentPixelsOnUpload(rgbaImageBytes, expectedResult)
+				etrace.clear()
+
+				Renderer:CreateTextureImage(rgbaImageBytes, IMAGE_WIDTH, IMAGE_HEIGHT)
+				local events = etrace.filter("GPU_TEXTURE_WRITE")
+				local payload = events[1].payload
+
+				assertEquals(events[1].name, "GPU_TEXTURE_WRITE")
+				assertEquals(payload.dataSize, IMAGE_WIDTH * IMAGE_HEIGHT * 4)
+				assertEquals(payload.writeSize.width, IMAGE_WIDTH)
+				assertEquals(payload.writeSize.height, IMAGE_HEIGHT)
+				assertEquals(payload.writeSize.depthOrArrayLayers, 1)
+
+				assertEquals(#payload.data, #rgbaImageBytes) -- More readable errors in case of failure
+				assertEquals(miniz.crc32(payload.data), miniz.crc32(expectedResult))
+
+				assertEquals(tonumber(events[1].payload.dataLayout.offset), 0)
+				assertEquals(tonumber(events[1].payload.dataLayout.bytesPerRow), IMAGE_WIDTH * 4)
+				assertEquals(tonumber(events[1].payload.dataLayout.rowsPerImage), IMAGE_HEIGHT)
+			end
+
+			assertRendererDiscardsTransparentPixelsOnUpload(transparentImages[1], expectedImages[1])
+			assertRendererDiscardsTransparentPixelsOnUpload(transparentImages[2], expectedImages[2])
+			assertRendererDiscardsTransparentPixelsOnUpload(transparentImages[3], expectedImages[3])
+			assertRendererDiscardsTransparentPixelsOnUpload(transparentImages[4], expectedImages[4])
+			assertRendererDiscardsTransparentPixelsOnUpload(transparentImages[5], expectedImages[5])
+			assertRendererDiscardsTransparentPixelsOnUpload(transparentImages[6], expectedImages[6])
+			assertRendererDiscardsTransparentPixelsOnUpload(transparentImages[7], expectedImages[7])
+			assertRendererDiscardsTransparentPixelsOnUpload(transparentImages[8], expectedImages[8])
+			assertRendererDiscardsTransparentPixelsOnUpload(transparentImages[9], expectedImages[9])
+			assertRendererDiscardsTransparentPixelsOnUpload(transparentImages[10], expectedImages[10])
+			assertRendererDiscardsTransparentPixelsOnUpload(transparentImages[11], expectedImages[11])
+			assertRendererDiscardsTransparentPixelsOnUpload(transparentImages[12], expectedImages[12])
+			assertRendererDiscardsTransparentPixelsOnUpload(transparentImages[13], expectedImages[13])
+			assertRendererDiscardsTransparentPixelsOnUpload(transparentImages[14], expectedImages[14])
+			assertRendererDiscardsTransparentPixelsOnUpload(transparentImages[15], expectedImages[15])
+			assertRendererDiscardsTransparentPixelsOnUpload(transparentImages[16], expectedImages[16])
 		end)
 	end)
 


### PR DESCRIPTION
Resolves #214. It's not at all optimized, can probably get a lot better by just moving it to the runtime (C++). Maybe later?