### PR TITLE
Allow the GRF decoder's DecodeFileName method to be used statically

### DIFF
--- a/Core/FileFormats/RagnarokGRF.lua
+++ b/Core/FileFormats/RagnarokGRF.lua
@@ -49,13 +49,13 @@ local RagnarokGRF = {
 		} grf_file_entry_t;
 	]],
 	HEADER_SIZE_IN_BYTES = 46,
+	preallocatedConversionBuffer = buffer.new(1024),
 }
 
 function RagnarokGRF:Construct()
 	local instance = {
 		pathToGRF = "",
 		fileTable = {},
-		preallocatedConversionBuffer = buffer.new(1024),
 	}
 
 	setmetatable(instance, self)

--- a/Tests/FileFormats/RagnarokGRF.spec.lua
+++ b/Tests/FileFormats/RagnarokGRF.spec.lua
@@ -288,54 +288,53 @@ describe("RagnarokGRF", function()
 	end)
 
 	describe("DecodeFileName", function()
-		local grf = RagnarokGRF()
 		it("should convert EUC-KR names to UTF8", function()
 			assertEquals(
-				grf:DecodeFileName("\xC0\xAF\xC0\xFA\xC0\xCE\xC5\xCD\xC6\xE4\xC0\xCC\xBD\xBA.txt"),
+				RagnarokGRF:DecodeFileName("\xC0\xAF\xC0\xFA\xC0\xCE\xC5\xCD\xC6\xE4\xC0\xCC\xBD\xBA.txt"),
 				"유저인터페이스.txt"
 			)
 
 			local inputString = "\xC0\xAF\xC0\xFA\xC0\xCE\xC5\xCD\xC6\xE4\xC0\xCC\xBD\xBA.txt\0"
 			local inputBuffer = buffer.new():put(inputString)
 			local pointerToNullTerminatedStringBytes = inputBuffer:ref()
-			assertEquals(grf:DecodeFileName(pointerToNullTerminatedStringBytes), "유저인터페이스.txt")
+			assertEquals(RagnarokGRF:DecodeFileName(pointerToNullTerminatedStringBytes), "유저인터페이스.txt")
 		end)
 
 		it("should convert upper-case to lower-case characters", function()
-			assertEquals(grf:DecodeFileName("TEST.BMP"), "test.bmp")
+			assertEquals(RagnarokGRF:DecodeFileName("TEST.BMP"), "test.bmp")
 
 			local inputString = "TEST.BMP\0"
 			local inputBuffer = buffer.new():put(inputString)
 			local pointerToNullTerminatedStringBytes = inputBuffer:ref()
-			assertEquals(grf:DecodeFileName(pointerToNullTerminatedStringBytes), "test.bmp")
+			assertEquals(RagnarokGRF:DecodeFileName(pointerToNullTerminatedStringBytes), "test.bmp")
 		end)
 
 		it("should remove leading path separators", function()
 			-- These are added by the HTTP route handler, but they're useless for path lookups
-			assertEquals(grf:DecodeFileName("/hello/world.txt"), "hello/world.txt")
+			assertEquals(RagnarokGRF:DecodeFileName("/hello/world.txt"), "hello/world.txt")
 
 			local inputString = "/hello/world.txt\0"
 			local inputBuffer = buffer.new():put(inputString)
 			local pointerToNullTerminatedStringBytes = inputBuffer:ref()
-			assertEquals(grf:DecodeFileName(pointerToNullTerminatedStringBytes), "hello/world.txt")
+			assertEquals(RagnarokGRF:DecodeFileName(pointerToNullTerminatedStringBytes), "hello/world.txt")
 		end)
 
 		it("should replace Windows path separators with POSIX ones", function()
-			assertEquals(grf:DecodeFileName("hello\\world.txt"), "hello/world.txt")
+			assertEquals(RagnarokGRF:DecodeFileName("hello\\world.txt"), "hello/world.txt")
 
 			local inputString = "hello\\world.txt\0"
 			local inputBuffer = buffer.new():put(inputString)
 			local pointerToNullTerminatedStringBytes = inputBuffer:ref()
-			assertEquals(grf:DecodeFileName(pointerToNullTerminatedStringBytes), "hello/world.txt")
+			assertEquals(RagnarokGRF:DecodeFileName(pointerToNullTerminatedStringBytes), "hello/world.txt")
 		end)
 
 		it("should remove duplicate path separators", function()
-			assertEquals(grf:DecodeFileName("hello\\\\world.txt"), "hello/world.txt")
+			assertEquals(RagnarokGRF:DecodeFileName("hello\\\\world.txt"), "hello/world.txt")
 
 			local inputString = "hello\\\\world.txt\0"
 			local inputBuffer = buffer.new():put(inputString)
 			local pointerToNullTerminatedStringBytes = inputBuffer:ref()
-			assertEquals(grf:DecodeFileName(pointerToNullTerminatedStringBytes), "hello/world.txt")
+			assertEquals(RagnarokGRF:DecodeFileName(pointerToNullTerminatedStringBytes), "hello/world.txt")
 		end)
 	end)
 end)


### PR DESCRIPTION
The preallocation happens in the constructor, but that isn't really required in this case since the method doesn't depend on the decoded file table (or other internal data). Multithreading isn't an issue here either, so there's no reason to not share a single conversion buffer. In fact, enabling the use of this as a static method makes it more convenient for other decoders to use the conversion code... although it's questionable that they should need to in the first place.