### PR TITLE
Rework the GRF extraction script to support multiple files

### DIFF
--- a/Tools/extract-from-grf.lua
+++ b/Tools/extract-from-grf.lua
@@ -1,14 +1,20 @@
 local RagnarokGRF = require("Core.FileFormats.RagnarokGRF")
 
-local fileToExtract = arg[1] or error("Arguments: fileToExtract [destinationFolder optionalArchiveName]")
-local grfPath = arg[3] or "data.grf"
-local destinationFolder = arg[2] or grfPath .. ".extracted"
-local destinationPath = path.join(destinationFolder, fileToExtract)
-
-C_FileSystem.MakeDirectoryTree(path.dirname(destinationPath))
-printf("Saving %s to %s", fileToExtract, destinationPath)
+local filesToExtract = { unpack(arg) }
+local grfPath = "data.grf"
+local destinationFolder = grfPath .. ".extracted"
 
 local grf = RagnarokGRF()
 grf:Open(grfPath)
-grf:ExtractFileToDisk(fileToExtract, destinationPath)
+
+printf("Extracting %d file(s) from archive %s into folder %s", #filesToExtract, grfPath, destinationFolder)
+
+for index, fileToExtract in ipairs(filesToExtract) do
+	local destinationPath = path.join(destinationFolder, fileToExtract)
+	C_FileSystem.MakeDirectoryTree(path.dirname(destinationPath))
+
+	printf("Saving %s to %s", fileToExtract, destinationPath)
+	grf:ExtractFileToDisk(fileToExtract, destinationPath)
+end
+
 grf:Close()


### PR DESCRIPTION
I don't think the capability of changing the GRF name and destination folder is worth more than being able to use shell tools to extract arbitrary numbers of files with a single command (to me, anyway).