### PR TITLE
Enable verbose output for the autoformat script

### DIFF
--- a/autoformat.sh
+++ b/autoformat.sh
@@ -1,1 +1,1 @@
-stylua .
+stylua . --verbose


### PR DESCRIPTION
This prints the time taken to format a given file, among other things. Since some database and test files are quite chunky, it could be useful to see when formatting them takes too much time to be worth it (so that it can be disabled).