### PR TITLE
Remove an unused field from the Renderer module

### DIFF
--- a/Core/NativeClient/Renderer.lua
+++ b/Core/NativeClient/Renderer.lua
@@ -57,7 +57,6 @@ local Renderer = {
 		} mesh_uniform_t;
 	]],
 	clearColorRGBA = { Color.GREY.red, Color.GREY.green, Color.GREY.blue, 0 },
-	renderPipelines = {},
 	userInterfaceTextureBindGroups = {},
 	meshes = {},
 	DEBUG_DISCARDED_BACKGROUND_PIXELS = false, -- This is really slow (disk I/O); don't enable unless necessary


### PR DESCRIPTION
It hasn't been used in a while, and the renderer shouldn't keep track of pipelines anyway (the code is already far too complicated).