### PR TITLE
Avoid repeatedly binding resources that change only once per frame for every mesh and UI widget

### DIFF
--- a/Core/NativeClient/Renderer.lua
+++ b/Core/NativeClient/Renderer.lua
@@ -203,6 +203,7 @@ function Renderer:RenderNextFrame()
 
 	do
 		local uiRenderPass = self:BeginUserInterfaceRenderPass(commandEncoder, nextTextureView)
+		RenderPassEncoder:SetBindGroup(uiRenderPass, 0, self.uniforms.perScene.bindGroup, 0, nil)
 		RenderPassEncoder:SetPipeline(uiRenderPass, self.userInterfaceRenderingPipeline)
 
 		self.numWidgetTransformsUsedThisFrame = 0
@@ -431,8 +432,6 @@ function Renderer:DrawWidget(renderPass, compiledWidgetGeometry, offsetU, offset
 		0,
 		indexBufferSize
 	)
-
-	RenderPassEncoder:SetBindGroup(renderPass, 0, self.uniforms.perScene.bindGroup, 0, nil)
 
 	if compiledWidgetGeometry.texture == ffi.NULL then
 		RenderPassEncoder:SetBindGroup(renderPass, 1, self.dummyTexture.wgpuBindGroup, 0, nil)

--- a/Core/NativeClient/Renderer.lua
+++ b/Core/NativeClient/Renderer.lua
@@ -185,7 +185,9 @@ function Renderer:RenderNextFrame()
 	do
 		local renderPass = self:BeginRenderPass(commandEncoder, nextTextureView)
 		self:ResetScissorRectangle(renderPass)
+
 		self:UpdateScenewideUniformBuffer()
+		RenderPassEncoder:SetBindGroup(renderPass, 0, self.uniforms.perScene.bindGroup, 0, nil)
 
 		local meshesByMaterial = self:SortMeshesByMaterial(self.meshes)
 		for material, meshes in pairs(meshesByMaterial) do
@@ -374,8 +376,6 @@ function Renderer:DrawMesh(renderPass, mesh)
 	RenderPassEncoder:SetVertexBuffer(renderPass, 1, mesh.colorBuffer, 0, colorBufferSize)
 	RenderPassEncoder:SetVertexBuffer(renderPass, 2, mesh.diffuseTexCoordsBuffer, 0, diffuseTexCoordsBufferSize)
 	RenderPassEncoder:SetIndexBuffer(renderPass, mesh.indexBuffer, ffi.C.WGPUIndexFormat_Uint32, 0, indexBufferSize)
-
-	RenderPassEncoder:SetBindGroup(renderPass, 0, self.uniforms.perScene.bindGroup, 0, nil)
 
 	-- Needs streamlining (later)
 	if not rawget(mesh, "diffuseTexture") then


### PR DESCRIPTION
This uniform data is changing exactly once per frame (in `UpdateScenewideUniformBuffer`), so there's no point in adding redundant API calls to the render pass encoder for every mesh. It's possible the implementation would optimize them away, and there aren't enough meshes being rendered for it to become a problem right now, but such a potential foot gun shouldn't be ignored. The same applies for the UI widgets, of which there is only one right now (but it has the same potential problem).