### PR TITLE
Streamline the use of localized ffi API references

### DIFF
--- a/Core/FileFormats/BinaryReader.lua
+++ b/Core/FileFormats/BinaryReader.lua
@@ -1,6 +1,6 @@
 local ffi = require("ffi")
 
-local ffi_cast = ffi.cast
+local cast = ffi.cast
 local sizeof = ffi.sizeof
 local ffi_string = ffi.string
 local type = type
@@ -73,7 +73,7 @@ function BinaryReader:GetUnsafePointer(numBytesToRead)
 		error(errorMessage, 0)
 	end
 
-	local cdataPointer = ffi_cast("uint8_t*", self.readOnlyBuffer) + self.virtualFilePointer
+	local cdataPointer = cast("uint8_t*", self.readOnlyBuffer) + self.virtualFilePointer
 	self.virtualFilePointer = self.virtualFilePointer + numBytesToRead
 
 	return cdataPointer
@@ -82,11 +82,11 @@ end
 function BinaryReader:GetTypedArray(cTypeName, numElements)
 	numElements = numElements or 1
 	local cdataPointer = self:GetUnsafePointer(sizeof(cTypeName) * numElements)
-	return ffi_cast(cTypeName .. "*", cdataPointer) -- Slightly inefficient (GC), but oh well
+	return cast(cTypeName .. "*", cdataPointer) -- Slightly inefficient (GC), but oh well
 end
 
 function BinaryReader:GetChar()
-	local cdataPointer = ffi_cast("char*", self:GetUnsafePointer(1))
+	local cdataPointer = cast("char*", self:GetUnsafePointer(1))
 	return tonumber(cdataPointer[0])
 end
 
@@ -111,52 +111,52 @@ function BinaryReader:GetCountedString(numBytesToRead)
 end
 
 function BinaryReader:GetFloat()
-	local cdataPointer = ffi_cast("float*", self:GetUnsafePointer(4))
+	local cdataPointer = cast("float*", self:GetUnsafePointer(4))
 	return tonumber(cdataPointer[0])
 end
 
 function BinaryReader:GetDouble()
-	local cdataPointer = ffi_cast("double*", self:GetUnsafePointer(8))
+	local cdataPointer = cast("double*", self:GetUnsafePointer(8))
 	return tonumber(cdataPointer[0])
 end
 
 function BinaryReader:GetInt64()
-	local cdataPointer = ffi_cast("int64_t*", self:GetUnsafePointer(8))
+	local cdataPointer = cast("int64_t*", self:GetUnsafePointer(8))
 	return tonumber(cdataPointer[0])
 end
 
 function BinaryReader:GetUnsignedInt64()
-	local cdataPointer = ffi_cast("uint64_t*", self:GetUnsafePointer(8))
+	local cdataPointer = cast("uint64_t*", self:GetUnsafePointer(8))
 	return tonumber(cdataPointer[0])
 end
 
 function BinaryReader:GetInt32()
-	local cdataPointer = ffi_cast("int32_t*", self:GetUnsafePointer(4))
+	local cdataPointer = cast("int32_t*", self:GetUnsafePointer(4))
 	return tonumber(cdataPointer[0])
 end
 
 function BinaryReader:GetUnsignedInt32()
-	local cdataPointer = ffi_cast("uint32_t*", self:GetUnsafePointer(4))
+	local cdataPointer = cast("uint32_t*", self:GetUnsafePointer(4))
 	return tonumber(cdataPointer[0])
 end
 
 function BinaryReader:GetInt16()
-	local cdataPointer = ffi_cast("int16_t*", self:GetUnsafePointer(2))
+	local cdataPointer = cast("int16_t*", self:GetUnsafePointer(2))
 	return tonumber(cdataPointer[0])
 end
 
 function BinaryReader:GetUnsignedInt16()
-	local cdataPointer = ffi_cast("uint16_t*", self:GetUnsafePointer(2))
+	local cdataPointer = cast("uint16_t*", self:GetUnsafePointer(2))
 	return tonumber(cdataPointer[0])
 end
 
 function BinaryReader:GetInt8()
-	local cdataPointer = ffi_cast("int8_t*", self:GetUnsafePointer(1))
+	local cdataPointer = cast("int8_t*", self:GetUnsafePointer(1))
 	return tonumber(cdataPointer[0])
 end
 
 function BinaryReader:GetUnsignedInt8()
-	local cdataPointer = ffi_cast("uint8_t*", self:GetUnsafePointer(1))
+	local cdataPointer = cast("uint8_t*", self:GetUnsafePointer(1))
 	return tonumber(cdataPointer[0])
 end
 

--- a/Core/FileFormats/BinaryReader.lua
+++ b/Core/FileFormats/BinaryReader.lua
@@ -1,7 +1,7 @@
 local ffi = require("ffi")
 
 local ffi_cast = ffi.cast
-local ffi_sizeof = ffi.sizeof
+local sizeof = ffi.sizeof
 local ffi_string = ffi.string
 local type = type
 
@@ -81,7 +81,7 @@ end
 
 function BinaryReader:GetTypedArray(cTypeName, numElements)
 	numElements = numElements or 1
-	local cdataPointer = self:GetUnsafePointer(ffi_sizeof(cTypeName) * numElements)
+	local cdataPointer = self:GetUnsafePointer(sizeof(cTypeName) * numElements)
 	return ffi_cast(cTypeName .. "*", cdataPointer) -- Slightly inefficient (GC), but oh well
 end
 

--- a/Core/FileFormats/RagnarokGRF.lua
+++ b/Core/FileFormats/RagnarokGRF.lua
@@ -12,7 +12,7 @@ local tonumber = tonumber
 local bit_band = bit.band
 local bit_rshift = bit.rshift
 local string_filesize = string.filesize
-local ffi_cast = ffi.cast
+local cast = ffi.cast
 local sizeof = ffi.sizeof
 local ffi_string = ffi.string
 local format = string.format
@@ -105,7 +105,7 @@ end
 function RagnarokGRF:DecodeHeader()
 	local headerSize = sizeof("grf_header_t")
 	local headerBytes = self.fileHandle:read(headerSize)
-	local header = ffi_cast("grf_header_t*", headerBytes)
+	local header = cast("grf_header_t*", headerBytes)
 
 	self.signature = ffi_string(header.signature)
 	if self.signature ~= "Master of Magic" then
@@ -137,7 +137,7 @@ function RagnarokGRF:DecodeTableHeader()
 
 	local tableSize = sizeof("grf_file_table_t")
 	local tableHeaderBytes = self.fileHandle:read(tableSize)
-	local tableHeader = ffi_cast("grf_file_table_t*", tableHeaderBytes)
+	local tableHeader = cast("grf_file_table_t*", tableHeaderBytes)
 
 	self.fileTable.compressedSizeInBytes = tonumber(tableHeader.compressed_size)
 	self.fileTable.decompressedSizeInBytes = tonumber(tableHeader.decompressed_size)
@@ -147,7 +147,7 @@ function RagnarokGRF:DecodeFileEntries()
 	local compressedTableBytes = self.fileHandle:read(self.fileTable.compressedSizeInBytes)
 	local decompressedTableBytes = zlib.inflate()(compressedTableBytes)
 
-	local movingConversionPointer = ffi_cast("char*", decompressedTableBytes)
+	local movingConversionPointer = cast("char*", decompressedTableBytes)
 
 	local entries = table.new(self.fileCount, 0)
 
@@ -157,7 +157,7 @@ function RagnarokGRF:DecodeFileEntries()
 		movingConversionPointer = movingConversionPointer + numProcessedBytesToSkip + 1 -- \0 terminator
 
 		-- Some redundancy could be removed here to reduce memory pressure, but it enables faster lookups
-		local entry = ffi_cast("grf_file_entry_t*", movingConversionPointer)
+		local entry = cast("grf_file_entry_t*", movingConversionPointer)
 		local fileEntry = {
 			name = normalizedCaseInsensitiveFilePath,
 			compressedSizeInBytes = tonumber(entry.compressed_size),

--- a/Core/FileFormats/RagnarokGRF.lua
+++ b/Core/FileFormats/RagnarokGRF.lua
@@ -13,7 +13,7 @@ local bit_band = bit.band
 local bit_rshift = bit.rshift
 local string_filesize = string.filesize
 local ffi_cast = ffi.cast
-local ffi_sizeof = ffi.sizeof
+local sizeof = ffi.sizeof
 local ffi_string = ffi.string
 local format = string.format
 local string_lower = string.lower
@@ -103,7 +103,7 @@ function RagnarokGRF:DecodeArchiveMetadata()
 end
 
 function RagnarokGRF:DecodeHeader()
-	local headerSize = ffi_sizeof("grf_header_t")
+	local headerSize = sizeof("grf_header_t")
 	local headerBytes = self.fileHandle:read(headerSize)
 	local header = ffi_cast("grf_header_t*", headerBytes)
 
@@ -135,7 +135,7 @@ end
 function RagnarokGRF:DecodeTableHeader()
 	self.fileHandle:seek("set", self.fileTableOffsetRelativeToHeader + RagnarokGRF.HEADER_SIZE_IN_BYTES)
 
-	local tableSize = ffi_sizeof("grf_file_table_t")
+	local tableSize = sizeof("grf_file_table_t")
 	local tableHeaderBytes = self.fileHandle:read(tableSize)
 	local tableHeader = ffi_cast("grf_file_table_t*", tableHeaderBytes)
 
@@ -169,7 +169,7 @@ function RagnarokGRF:DecodeFileEntries()
 		entries[#entries + 1] = fileEntry
 		entries[normalizedCaseInsensitiveFilePath] = fileEntry
 
-		movingConversionPointer = movingConversionPointer + ffi_sizeof("grf_file_entry_t")
+		movingConversionPointer = movingConversionPointer + sizeof("grf_file_entry_t")
 	end
 
 	self.fileTable.entries = entries
@@ -344,6 +344,6 @@ function RagnarokGRF:MakeFileSystem(name)
 end
 
 ffi.cdef(RagnarokGRF.cdefs)
-assert(RagnarokGRF.HEADER_SIZE_IN_BYTES == ffi_sizeof("grf_header_t")) -- Basic sanity check
+assert(RagnarokGRF.HEADER_SIZE_IN_BYTES == sizeof("grf_header_t")) -- Basic sanity check
 
 return RagnarokGRF

--- a/Core/FileFormats/RagnarokPAL.lua
+++ b/Core/FileFormats/RagnarokPAL.lua
@@ -1,6 +1,6 @@
 local ffi = require("ffi")
 
-local ffi_cast = ffi.cast
+local cast = ffi.cast
 local ffi_copy = ffi.copy
 local new = ffi.new
 local sizeof = ffi.sizeof
@@ -29,7 +29,7 @@ function RagnarokPAL:DecodeFileContents(fileContents)
 	end
 
 	local bufferAreaStartPointer = fileContents:ref()
-	local paletteBytes = ffi_cast("spr_palette_t*", bufferAreaStartPointer + paletteStartOffset)
+	local paletteBytes = cast("spr_palette_t*", bufferAreaStartPointer + paletteStartOffset)
 
 	-- Must copy to create a GC anchor here before the buffer is collected (probably not a big deal?)
 	local bmpColorPalette = new("spr_palette_t[1]", paletteBytes[0])

--- a/Core/FileFormats/RagnarokPAL.lua
+++ b/Core/FileFormats/RagnarokPAL.lua
@@ -2,7 +2,7 @@ local ffi = require("ffi")
 
 local ffi_cast = ffi.cast
 local ffi_copy = ffi.copy
-local ffi_new = ffi.new
+local new = ffi.new
 local ffi_sizeof = ffi.sizeof
 
 local RagnarokPAL = {
@@ -32,8 +32,8 @@ function RagnarokPAL:DecodeFileContents(fileContents)
 	local paletteBytes = ffi_cast("spr_palette_t*", bufferAreaStartPointer + paletteStartOffset)
 
 	-- Must copy to create a GC anchor here before the buffer is collected (probably not a big deal?)
-	local bmpColorPalette = ffi_new("spr_palette_t[1]", paletteBytes[0])
-	local newColors = ffi_new("spr_palette_t")
+	local bmpColorPalette = new("spr_palette_t[1]", paletteBytes[0])
+	local newColors = new("spr_palette_t")
 
 	ffi_copy(newColors, bmpColorPalette[0], ffi_sizeof("spr_palette_t"))
 	return newColors

--- a/Core/FileFormats/RagnarokPAL.lua
+++ b/Core/FileFormats/RagnarokPAL.lua
@@ -3,7 +3,7 @@ local ffi = require("ffi")
 local ffi_cast = ffi.cast
 local ffi_copy = ffi.copy
 local new = ffi.new
-local ffi_sizeof = ffi.sizeof
+local sizeof = ffi.sizeof
 
 local RagnarokPAL = {
 	cdefs = [[
@@ -22,7 +22,7 @@ local RagnarokPAL = {
 
 function RagnarokPAL:DecodeFileContents(fileContents)
 	local endOfFileOffset = #fileContents
-	local paletteStartOffset = endOfFileOffset - ffi_sizeof("spr_palette_t")
+	local paletteStartOffset = endOfFileOffset - sizeof("spr_palette_t")
 
 	if type(fileContents) == "string" then -- Can't use Lua strings as a buffer directly
 		fileContents = buffer.new(#fileContents):put(fileContents)
@@ -35,7 +35,7 @@ function RagnarokPAL:DecodeFileContents(fileContents)
 	local bmpColorPalette = new("spr_palette_t[1]", paletteBytes[0])
 	local newColors = new("spr_palette_t")
 
-	ffi_copy(newColors, bmpColorPalette[0], ffi_sizeof("spr_palette_t"))
+	ffi_copy(newColors, bmpColorPalette[0], sizeof("spr_palette_t"))
 	return newColors
 end
 

--- a/Core/FileFormats/RagnarokPAL.lua
+++ b/Core/FileFormats/RagnarokPAL.lua
@@ -1,7 +1,7 @@
 local ffi = require("ffi")
 
 local cast = ffi.cast
-local ffi_copy = ffi.copy
+local copy = ffi.copy
 local new = ffi.new
 local sizeof = ffi.sizeof
 
@@ -35,7 +35,7 @@ function RagnarokPAL:DecodeFileContents(fileContents)
 	local bmpColorPalette = new("spr_palette_t[1]", paletteBytes[0])
 	local newColors = new("spr_palette_t")
 
-	ffi_copy(newColors, bmpColorPalette[0], sizeof("spr_palette_t"))
+	copy(newColors, bmpColorPalette[0], sizeof("spr_palette_t"))
 	return newColors
 end
 

--- a/Core/FileFormats/RagnarokSPR.lua
+++ b/Core/FileFormats/RagnarokSPR.lua
@@ -9,7 +9,7 @@ local printf = printf
 local tonumber = tonumber
 
 local ffi_cast = ffi.cast
-local ffi_new = ffi.new
+local new = ffi.new
 local ffi_sizeof = ffi.sizeof
 local uv_hrtime = uv.hrtime
 
@@ -85,13 +85,13 @@ function RagnarokSPR:DecompressRunLengthEncodedBytes(compressedBuffer, decompres
 		if isDecompressingRunOfZeroes then
 			local numZeroesToAdd = currentByte - 1
 			if numZeroesToAdd > 0 then
-				decompressedBuffer:putcdata(ffi_new("uint8_t[?]", numZeroesToAdd), numZeroesToAdd)
+				decompressedBuffer:putcdata(new("uint8_t[?]", numZeroesToAdd), numZeroesToAdd)
 			elseif numZeroesToAdd < 0 then
 				error(format("Encountered zero-length run at index %s (not an RLE-encoded image?)", byteIndex), 0)
 			end
 			isDecompressingRunOfZeroes = false
 		else
-			decompressedBuffer:putcdata(ffi_new("uint8_t[1]", currentByte), 1)
+			decompressedBuffer:putcdata(new("uint8_t[1]", currentByte), 1)
 			if currentByte == 0 then
 				isDecompressingRunOfZeroes = true
 			end
@@ -187,7 +187,7 @@ function RagnarokSPR:DecodeTrueColorImages()
 		return -- No TGA segment present
 	end
 
-	local image = ffi_new("stbi_image_t")
+	local image = new("stbi_image_t")
 	image.channels = 4
 
 	local reader = self.reader

--- a/Core/FileFormats/RagnarokSPR.lua
+++ b/Core/FileFormats/RagnarokSPR.lua
@@ -10,7 +10,7 @@ local tonumber = tonumber
 
 local ffi_cast = ffi.cast
 local new = ffi.new
-local ffi_sizeof = ffi.sizeof
+local sizeof = ffi.sizeof
 local uv_hrtime = uv.hrtime
 
 local RagnarokSPR = {}
@@ -71,7 +71,7 @@ end
 function RagnarokSPR:DecodeColorPalette()
 	local reader = self.reader
 
-	self.paletteStartOffset = reader.endOfFilePointer - ffi_sizeof("spr_palette_t")
+	self.paletteStartOffset = reader.endOfFilePointer - sizeof("spr_palette_t")
 	self.palette = reader:GetTypedArray("spr_palette_t")
 end
 
@@ -119,7 +119,7 @@ function RagnarokSPR:ApplyColorPalette(indexedColorImageBytes, palette)
 		else
 			paletteColor.alpha = 255 -- BMP alpha is not supported (except for the background color)
 		end
-		rgbaImageBytes:putcdata(paletteColor, ffi_sizeof(paletteColor))
+		rgbaImageBytes:putcdata(paletteColor, sizeof(paletteColor))
 	end
 
 	return rgbaImageBytes

--- a/Core/FileFormats/RagnarokSPR.lua
+++ b/Core/FileFormats/RagnarokSPR.lua
@@ -8,7 +8,7 @@ local uv = require("uv")
 local printf = printf
 local tonumber = tonumber
 
-local ffi_cast = ffi.cast
+local cast = ffi.cast
 local new = ffi.new
 local sizeof = ffi.sizeof
 local uv_hrtime = uv.hrtime
@@ -76,7 +76,7 @@ function RagnarokSPR:DecodeColorPalette()
 end
 
 function RagnarokSPR:DecompressRunLengthEncodedBytes(compressedBuffer, decompressedBuffer)
-	local compressedBytes = ffi_cast("uint8_t*", compressedBuffer:ref())
+	local compressedBytes = cast("uint8_t*", compressedBuffer:ref())
 	local isDecompressingRunOfZeroes = false
 
 	for byteIndex = 0, #compressedBuffer - 1 do
@@ -109,7 +109,7 @@ function RagnarokSPR:ApplyColorPalette(indexedColorImageBytes, palette)
 
 	local startPointer = indexedColorImageBytes:ref()
 
-	local paletteIndices = ffi_cast("uint8_t*", startPointer)
+	local paletteIndices = cast("uint8_t*", startPointer)
 
 	for byteIndex = 0, #indexedColorImageBytes - 1, 1 do
 		local paletteIndex = tonumber(paletteIndices[byteIndex])
@@ -199,7 +199,7 @@ function RagnarokSPR:DecodeTrueColorImages()
 		local pixelBuffer = buffer.new(pixelBufferSize)
 
 		local abgrPixelBytes = reader:GetTypedArray("uint8_t", pixelBufferSize)
-		local abgrPixelArray = ffi_cast("stbi_pixelbuffer_t", abgrPixelBytes) -- TBD redundant, can remove?
+		local abgrPixelArray = cast("stbi_pixelbuffer_t", abgrPixelBytes) -- TBD redundant, can remove?
 		image.data = abgrPixelArray
 
 		stbi.bindings.stbi_abgr_to_rgba(image)

--- a/Core/NativeClient/Renderer.lua
+++ b/Core/NativeClient/Renderer.lua
@@ -29,7 +29,7 @@ local assert = assert
 local ipairs = ipairs
 local rawget = rawget
 
-local ffi_new = ffi.new
+local new = ffi.new
 local format = string.format
 local filesize = string.filesize
 local table_insert = table.insert
@@ -179,7 +179,7 @@ function Renderer:RenderNextFrame()
 	etrace.clear()
 	local nextTextureView = self.backingSurface:AcquireTextureView()
 
-	local commandEncoderDescriptor = ffi_new("WGPUCommandEncoderDescriptor")
+	local commandEncoderDescriptor = new("WGPUCommandEncoderDescriptor")
 	local commandEncoder = Device:CreateCommandEncoder(self.wgpuDevice, commandEncoderDescriptor)
 
 	do
@@ -320,11 +320,11 @@ end
 
 function Renderer:BeginRenderPass(commandEncoder, nextTextureView)
 	-- Clearing is a built-in mechanism of the render pass
-	local renderPassColorAttachment = ffi_new("WGPURenderPassColorAttachment", {
+	local renderPassColorAttachment = new("WGPURenderPassColorAttachment", {
 		view = nextTextureView,
 		loadOp = ffi.C.WGPULoadOp_Clear,
 		storeOp = ffi.C.WGPUStoreOp_Store,
-		clearValue = ffi_new("WGPUColor", self.clearColorRGBA),
+		clearValue = new("WGPUColor", self.clearColorRGBA),
 	})
 
 	-- Enable Z buffering in the fragment stage
@@ -341,7 +341,7 @@ function Renderer:BeginRenderPass(commandEncoder, nextTextureView)
 		stencilReadOnly = true,
 	})
 
-	local renderPassDescriptor = ffi_new("WGPURenderPassDescriptor", {
+	local renderPassDescriptor = new("WGPURenderPassDescriptor", {
 		colorAttachmentCount = 1,
 		colorAttachments = renderPassColorAttachment,
 		depthStencilAttachment = depthStencilAttachment,
@@ -351,14 +351,14 @@ function Renderer:BeginRenderPass(commandEncoder, nextTextureView)
 end
 
 function Renderer:BeginUserInterfaceRenderPass(commandEncoder, nextTextureView)
-	local renderPassColorAttachment = ffi_new("WGPURenderPassColorAttachment", {
+	local renderPassColorAttachment = new("WGPURenderPassColorAttachment", {
 		view = nextTextureView,
 		loadOp = ffi.C.WGPULoadOp_Load, -- Preserve existing framebuffer content
 		storeOp = ffi.C.WGPUStoreOp_Store,
-		clearValue = ffi_new("WGPUColor", self.clearColorRGBA),
+		clearValue = new("WGPUColor", self.clearColorRGBA),
 	})
 
-	local renderPassDescriptor = ffi_new("WGPURenderPassDescriptor", {
+	local renderPassDescriptor = new("WGPURenderPassDescriptor", {
 		colorAttachmentCount = 1,
 		colorAttachments = renderPassColorAttachment,
 		-- Depth/stencil testing is omitted since it isn't needed for UI rendering
@@ -462,12 +462,12 @@ function Renderer:DrawWidget(renderPass, compiledWidgetGeometry, offsetU, offset
 end
 
 function Renderer:SubmitCommandBuffer(commandEncoder)
-	local commandBufferDescriptor = ffi_new("WGPUCommandBufferDescriptor")
+	local commandBufferDescriptor = new("WGPUCommandBufferDescriptor")
 	local commandBuffer = CommandEncoder:Finish(commandEncoder, commandBufferDescriptor)
 
 	-- The WebGPU API expects an array here, but currently this renderer only supports a single buffer (to keep things simple)
 	local queue = Device:GetQueue(self.wgpuDevice)
-	local commandBuffers = ffi_new("WGPUCommandBuffer[1]", commandBuffer)
+	local commandBuffers = new("WGPUCommandBuffer[1]", commandBuffer)
 	Queue:Submit(queue, 1, commandBuffers)
 end
 

--- a/Core/NativeClient/WebGPU/GPU.lua
+++ b/Core/NativeClient/WebGPU/GPU.lua
@@ -5,6 +5,7 @@ local glfw = require("glfw")
 local webgpu = require("webgpu")
 
 local new = ffi.new
+local ffi_string = ffi.string
 
 local GPU = {
 	MAX_VERTEX_COUNT = 200000, -- Should be configurable (later)
@@ -91,7 +92,7 @@ function GPU:RequestLogicalDevice(adapter, options)
 				format(
 					"Failed to request logical WebGPU device (status: %s)\n%s",
 					tonumber(status),
-					ffi.string(message)
+					ffi_string(message)
 				)
 			)
 		end
@@ -103,7 +104,7 @@ function GPU:RequestLogicalDevice(adapter, options)
 	assert(requestedDevice, "onDeviceRequested did not trigger, but it should have")
 
 	local function onDeviceError(errorType, message, userdata)
-		local errorDetails = format("Type: %s, Message: %s", tonumber(errorType), ffi.string(message))
+		local errorDetails = format("Type: %s, Message: %s", tonumber(errorType), ffi_string(message))
 		error("Uncaptured device error - " .. errorDetails)
 	end
 

--- a/Core/NativeClient/WebGPU/Surface.lua
+++ b/Core/NativeClient/WebGPU/Surface.lua
@@ -5,7 +5,7 @@ local webgpu = require("webgpu")
 local assert = assert
 local tonumber = tonumber
 
-local ffi_new = ffi.new
+local new = ffi.new
 
 local Surface = {}
 
@@ -16,9 +16,9 @@ function Surface:Construct(wgpuInstance, wgpuAdapter, wgpuDevice, glfwWindow)
 	self.glfwWindow = glfwWindow
 
 	self.wgpuSurface = glfw.bindings.glfw_get_wgpu_surface(wgpuInstance, glfwWindow)
-	self.wgpuSurfaceConfiguration = ffi_new("WGPUSurfaceConfiguration")
-	self.wgpuSurfaceTexture = ffi_new("WGPUSurfaceTexture")
-	self.wgpuTextureViewDescriptor = ffi_new("WGPUTextureViewDescriptor")
+	self.wgpuSurfaceConfiguration = new("WGPUSurfaceConfiguration")
+	self.wgpuSurfaceTexture = new("WGPUSurfaceTexture")
+	self.wgpuTextureViewDescriptor = new("WGPUTextureViewDescriptor")
 
 	return self
 end
@@ -78,8 +78,8 @@ function Surface:GetAspectRatio()
 	return self.wgpuSurfaceConfiguration.width / self.wgpuSurfaceConfiguration.height
 end
 
-local contentWidthInPixels = ffi_new("int[1]")
-local contentHeightInPixels = ffi_new("int[1]")
+local contentWidthInPixels = new("int[1]")
+local contentHeightInPixels = new("int[1]")
 function Surface:GetViewportSize()
 	-- Should probably differentiate between window and frame buffer here for high-DPI (later)
 	glfw.bindings.glfw_get_window_size(self.glfwWindow, contentWidthInPixels, contentHeightInPixels)

--- a/Core/VectorMath/Matrix3D.lua
+++ b/Core/VectorMath/Matrix3D.lua
@@ -1,7 +1,7 @@
 local ffi = require("ffi")
 local transform = require("transform")
 
-local ffi_new = ffi.new
+local new = ffi.new
 local format = string.format
 local math_cos = math.cos
 local math_sin = math.sin
@@ -46,7 +46,7 @@ function Matrix3D:__tostring()
 end
 
 function Matrix3D:CreateIdentity()
-	local identityMatrix = ffi_new("Matrix3D")
+	local identityMatrix = new("Matrix3D")
 
 	identityMatrix.x1, identityMatrix.y2, identityMatrix.z3 = 1, 1, 1
 
@@ -60,7 +60,7 @@ end
 function Matrix3D:CreateAxisRotationX(rotationAngleInDegrees)
 	local rotationAngleInRadians = deg2rad(rotationAngleInDegrees)
 
-	local rotationMatrix = ffi_new("Matrix3D")
+	local rotationMatrix = new("Matrix3D")
 
 	rotationMatrix.x1 = 1
 	rotationMatrix.y2 = math_cos(rotationAngleInRadians)
@@ -74,7 +74,7 @@ end
 function Matrix3D:CreateAxisRotationY(rotationAngleInDegrees)
 	local rotationAngleInRadians = deg2rad(rotationAngleInDegrees)
 
-	local rotationMatrix = ffi_new("Matrix3D")
+	local rotationMatrix = new("Matrix3D")
 
 	rotationMatrix.x1 = math_cos(rotationAngleInRadians)
 	rotationMatrix.x3 = -math_sin(rotationAngleInRadians)

--- a/Core/VectorMath/Matrix4D.lua
+++ b/Core/VectorMath/Matrix4D.lua
@@ -1,7 +1,7 @@
 local ffi = require("ffi")
 local transform = require("transform")
 
-local ffi_new = ffi.new
+local new = ffi.new
 local format = string.format
 local transform_bold = transform.bold
 
@@ -59,7 +59,7 @@ function Matrix4D:__tostring()
 end
 
 function Matrix4D:CreateIdentity()
-	local identityMatrix = ffi_new("Matrix4D")
+	local identityMatrix = new("Matrix4D")
 
 	identityMatrix.x1, identityMatrix.y2, identityMatrix.z3, identityMatrix.w4 = 1, 1, 1, 1
 

--- a/Core/VectorMath/Vector3D.lua
+++ b/Core/VectorMath/Vector3D.lua
@@ -2,7 +2,7 @@ local ffi = require("ffi")
 local transform = require("transform")
 
 local format = format
-local ffi_new = ffi.new
+local new = ffi.new
 local math_sqrt = math.sqrt
 local transform_bold = transform.bold
 
@@ -27,7 +27,7 @@ function Vector3D:__tostring()
 end
 
 function Vector3D:Add(anotherVector)
-	local result = ffi_new("Vector3D")
+	local result = new("Vector3D")
 	result.x = self.x + anotherVector.x
 	result.y = self.y + anotherVector.y
 	result.z = self.z + anotherVector.z
@@ -35,7 +35,7 @@ function Vector3D:Add(anotherVector)
 end
 
 function Vector3D:Subtract(anotherVector)
-	local result = ffi_new("Vector3D")
+	local result = new("Vector3D")
 	result.x = self.x - anotherVector.x
 	result.y = self.y - anotherVector.y
 	result.z = self.z - anotherVector.z

--- a/Tests/NativeClient/WebGPU/Texture.spec.lua
+++ b/Tests/NativeClient/WebGPU/Texture.spec.lua
@@ -1,5 +1,7 @@
 local ffi = require("ffi")
 
+local ffi_string = ffi.string
+
 local Color = require("Core.NativeClient.DebugDraw.Color")
 local Texture = require("Core.NativeClient.WebGPU.Texture")
 
@@ -26,7 +28,7 @@ describe("Texture", function()
 			local imageFilePath = path.join("Tests", "Fixtures", "gradient-texture.png")
 			local pngImageBytes = C_FileSystem.ReadFile(imageFilePath)
 			local expectedPixelData = C_ImageProcessing.DecodeFileContents(pngImageBytes)
-			assertEquals(ffi.string(rgbaImageBytes, 256 * 256 * 4), expectedPixelData)
+			assertEquals(ffi_string(rgbaImageBytes, 256 * 256 * 4), expectedPixelData)
 		end)
 
 		it("should throw if the dimensions aren't a power of two", function()
@@ -67,19 +69,19 @@ describe("Texture", function()
 			local imageFilePath = path.join("Tests", "Fixtures", "blank-texture.png")
 			local pngImageBytes = C_FileSystem.ReadFile(imageFilePath)
 			local expectedPixelData = C_ImageProcessing.DecodeFileContents(pngImageBytes)
-			assertEquals(ffi.string(rgbaImageBytes, 256 * 256 * 4), expectedPixelData)
+			assertEquals(ffi_string(rgbaImageBytes, 256 * 256 * 4), expectedPixelData)
 		end)
 
 		it("should return the RGBA pixel data for a solid colored texture if a color was passed", function()
 			local rgbaImageBytes = Texture:GenerateBlankImage(256, 256, Color.RED)
 			local expectedPixelData = string.rep("\255\0\0\255", 256 * 256)
-			assertEquals(ffi.string(rgbaImageBytes, 256 * 256 * 4), expectedPixelData)
+			assertEquals(ffi_string(rgbaImageBytes, 256 * 256 * 4), expectedPixelData)
 		end)
 
 		it("should return the RGBA pixel data for a texture of the given dimensions", function()
 			local rgbaImageBytes = Texture:GenerateBlankImage(32, 32, Color.RED)
 			local expectedPixelData = string.rep("\255\0\0\255", 32 * 32)
-			assertEquals(ffi.string(rgbaImageBytes, 32 * 32 * 4), expectedPixelData)
+			assertEquals(ffi_string(rgbaImageBytes, 32 * 32 * 4), expectedPixelData)
 		end)
 
 		it("should throw if the dimensions aren't a power of two", function()
@@ -161,7 +163,7 @@ describe("Texture", function()
 			local imageFilePath = path.join("Tests", "Fixtures", "grid-texture.png")
 			local pngImageBytes = C_FileSystem.ReadFile(imageFilePath)
 			local expectedPixelData = C_ImageProcessing.DecodeFileContents(pngImageBytes)
-			assertEquals(ffi.string(rgbaImageBytes, 256 * 256 * 4), expectedPixelData)
+			assertEquals(ffi_string(rgbaImageBytes, 256 * 256 * 4), expectedPixelData)
 		end)
 
 		it("should return the RGBA pixel data for a matching grid texture if two colors were passed", function()
@@ -171,7 +173,7 @@ describe("Texture", function()
 			local imageFilePath = path.join("Tests", "Fixtures", "colored-grid-texture.png")
 			local pngImageBytes = C_FileSystem.ReadFile(imageFilePath)
 			local expectedPixelData = C_ImageProcessing.DecodeFileContents(pngImageBytes)
-			assertEquals(ffi.string(rgbaImageBytes, 256 * 256 * 4), expectedPixelData)
+			assertEquals(ffi_string(rgbaImageBytes, 256 * 256 * 4), expectedPixelData)
 		end)
 
 		it("should throw if the dimensions aren't a power of two", function()


### PR DESCRIPTION
Removing the upvalues entirely isn't advisable as global lookups still generate more instructions*, but the use of localized FFI calls should be consistent across the codebase.

(*Based on these benchmarks, which I haven't personally verified: https://gitspartv.github.io/LuaJIT-Benchmarks/)