### PR TITLE
Disable git's autocrlf feature in the Windows CI runner

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -25,6 +25,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
+      - name: Disable autocrlf # Messes up everything on Windows since fixtures are saved with \n
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
       - name: Check out Git repository
         uses: actions/checkout@v4
 

--- a/Tests/FileFormats/RagnarokACT.spec.lua
+++ b/Tests/FileFormats/RagnarokACT.spec.lua
@@ -1,7 +1,5 @@
 local RagnarokACT = require("Core.FileFormats.RagnarokACT")
 
-local json = require("json")
-
 local ACTV2_0_EXAMPLE = C_FileSystem.ReadFile(path.join("Tests", "Fixtures", "v0200.act"))
 local ACTV2_1_EXAMPLE = C_FileSystem.ReadFile(path.join("Tests", "Fixtures", "v0201.act"))
 local ACTV2_3_EXAMPLE = C_FileSystem.ReadFile(path.join("Tests", "Fixtures", "v0203.act"))
@@ -15,7 +13,7 @@ describe("RagnarokACT", function()
 			act:DecodeFileContents(ACTV2_0_EXAMPLE)
 			local actual = act:ToJSON()
 			local expected = C_FileSystem.ReadFile(path.join("Tests", "Fixtures", "Snapshots", "v0200.act.json"))
-			assertEquals(json.parse(actual), json.parse(expected)) -- Workaround for encoding issues in the CI :/
+			assertEquals(actual, expected)
 		end)
 
 		it("should be able to decode ACT files using version 2.1 of the format", function()
@@ -23,7 +21,7 @@ describe("RagnarokACT", function()
 			act:DecodeFileContents(ACTV2_1_EXAMPLE)
 			local actual = act:ToJSON()
 			local expected = C_FileSystem.ReadFile(path.join("Tests", "Fixtures", "Snapshots", "v0201.act.json"))
-			assertEquals(json.parse(actual), json.parse(expected)) -- Workaround for encoding issues in the CI :/
+			assertEquals(actual, expected)
 		end)
 
 		it("should be able to decode ACT files using version 2.3 of the format", function()
@@ -31,7 +29,7 @@ describe("RagnarokACT", function()
 			act:DecodeFileContents(ACTV2_3_EXAMPLE)
 			local actual = act:ToJSON()
 			local expected = C_FileSystem.ReadFile(path.join("Tests", "Fixtures", "Snapshots", "v0203.act.json"))
-			assertEquals(json.parse(actual), json.parse(expected)) -- Workaround for encoding issues in the CI :/
+			assertEquals(actual, expected)
 		end)
 
 		it("should be able to decode ACT files using version 2.4 of the format", function()
@@ -39,7 +37,7 @@ describe("RagnarokACT", function()
 			act:DecodeFileContents(ACTV2_4_EXAMPLE)
 			local actual = act:ToJSON()
 			local expected = C_FileSystem.ReadFile(path.join("Tests", "Fixtures", "Snapshots", "v0204.act.json"))
-			assertEquals(json.parse(actual), json.parse(expected)) -- Workaround for encoding issues in the CI :/
+			assertEquals(actual, expected)
 		end)
 
 		it("should be able to decode ACT files using version 2.5 of the format", function()
@@ -47,7 +45,7 @@ describe("RagnarokACT", function()
 			act:DecodeFileContents(ACTV2_5_EXAMPLE)
 			local actual = act:ToJSON()
 			local expected = C_FileSystem.ReadFile(path.join("Tests", "Fixtures", "Snapshots", "v0205.act.json"))
-			assertEquals(json.parse(actual), json.parse(expected)) -- Workaround for encoding issues in the CI :/
+			assertEquals(actual, expected)
 		end)
 	end)
 end)

--- a/Tests/FileFormats/RagnarokGND.spec.lua
+++ b/Tests/FileFormats/RagnarokGND.spec.lua
@@ -575,7 +575,7 @@ describe("RagnarokGND", function()
 			-- Leaving this here because the snapshot likely needs to be recreated once lightmaps/normals are needed
 			-- C_FileSystem.WriteFile(path.join("Tests", "Fixtures", "Snapshots", "gnd-geometry.json"), jsonDump)
 			local snapshot = C_FileSystem.ReadFile(path.join("Tests", "Fixtures", "Snapshots", "gnd-geometry.json"))
-			assertEquals(json.parse(jsonDump), json.parse(snapshot)) -- Workaround for encoding issues in the CI :/
+			assertEquals(jsonDump, snapshot)
 		end)
 	end)
 end)


### PR DESCRIPTION
This probably explains the issues with test fixtures failing the equality comparison in some of the decoder test cases?