### PR TITLE
Remove the obsolete package.path adjustments

### DIFF
--- a/Tests/smoke-test.lua
+++ b/Tests/smoke-test.lua
@@ -1,5 +1,3 @@
-package.path = "?.lua"
-
 local specFiles = {
 	"Tests/DB/validate-creature-spawns.lua",
 	"Tests/DB/validate-map-database.lua",

--- a/Tests/unit-test.lua
+++ b/Tests/unit-test.lua
@@ -1,5 +1,3 @@
-package.path = "?.lua"
-
 require("Core.RuntimeExtensions.C_Runtime")
 
 local specFiles = {

--- a/client.lua
+++ b/client.lua
@@ -1,5 +1,3 @@
-package.path = "?.lua"
-
 local NativeClient = require("Core.NativeClient.NativeClient")
 
 if arg[1] == "--etrace" then

--- a/server.lua
+++ b/server.lua
@@ -1,5 +1,3 @@
-package.path = "?.lua"
-
 local WorldServer = require("Core.WorldServer.WorldServer")
 
 WorldServer:Start()


### PR DESCRIPTION
Not sure why I added those, require should "just work" from the current working directory by default?