### PR TITLE
Implement delta time updates for the WebGPU renderer

### DIFF
--- a/Core/NativeClient/NativeClient.lua
+++ b/Core/NativeClient/NativeClient.lua
@@ -109,7 +109,9 @@ function NativeClient:StartRenderLoop()
 		local replayTime = uv.hrtime() - replayStartTime
 
 		local frameStartTime = uv.hrtime()
-		local cpuFrameTime, worldRenderTime, uiRenderTime, commandSubmissionTime = Renderer:RenderNextFrame()
+		local deltaTime = self.lastFrameStartTime and (frameStartTime - self.lastFrameStartTime) or 0
+		self.lastFrameStartTime = frameStartTime
+		local cpuFrameTime, worldRenderTime, uiRenderTime, commandSubmissionTime = Renderer:RenderNextFrame(deltaTime)
 		local frameEndTime = uv.hrtime()
 
 		local frameTimeInMilliseconds = (frameEndTime - frameStartTime) / 10E5

--- a/Core/NativeClient/Renderer.lua
+++ b/Core/NativeClient/Renderer.lua
@@ -172,7 +172,7 @@ function Renderer:SortMeshesByMaterial(meshes)
 	return meshesSortedByMaterial
 end
 
-function Renderer:RenderNextFrame()
+function Renderer:RenderNextFrame(deltaTime)
 	etrace.clear()
 
 	-- Blocking call in VSYNC present mode, so timing this isn't particularly helpful

--- a/Core/NativeClient/Renderer.lua
+++ b/Core/NativeClient/Renderer.lua
@@ -186,7 +186,7 @@ function Renderer:RenderNextFrame(deltaTime)
 		local renderPass = self:BeginRenderPass(commandEncoder, nextTextureView)
 		self:ResetScissorRectangle(renderPass)
 
-		self:UpdateScenewideUniformBuffer()
+		self:UpdateScenewideUniformBuffer(deltaTime)
 		RenderPassEncoder:SetBindGroup(renderPass, 0, self.cameraViewportUniform.bindGroup, 0, nil)
 
 		local meshesByMaterial = self:SortMeshesByMaterial(self.meshes)
@@ -620,7 +620,7 @@ function Renderer:CreateUniformBuffers()
 	}
 end
 
-function Renderer:UpdateScenewideUniformBuffer()
+function Renderer:UpdateScenewideUniformBuffer(deltaTime)
 	local aspectRatio = self.backingSurface:GetAspectRatio()
 	local viewportWidth, viewportHeight = self.backingSurface:GetViewportSize()
 
@@ -636,6 +636,7 @@ function Renderer:UpdateScenewideUniformBuffer()
 	perSceneUniformData.perspectiveProjection =
 		C_Camera.CreatePerspectiveProjection(perspective.fov, aspectRatio, perspective.nearZ, perspective.farZ)
 	perSceneUniformData.color = ffi.new("float[4]", { 1.0, 1.0, 1.0, 1.0 })
+	perSceneUniformData.deltaTime = deltaTime
 
 	Queue:WriteBuffer(
 		Device:GetQueue(self.wgpuDevice),

--- a/Core/NativeClient/WebGPU/Shaders/BasicTriangleShader.wgsl
+++ b/Core/NativeClient/WebGPU/Shaders/BasicTriangleShader.wgsl
@@ -17,6 +17,7 @@ struct PerSceneData {
 	color: vec4f,
 	viewportWidth: f32,
 	viewportHeight: f32,
+	deltaTime: f32,
 };
 
 @group(0) @binding(0) var<uniform> uPerSceneData: PerSceneData;

--- a/Core/NativeClient/WebGPU/Shaders/UserInterfaceShader.wgsl
+++ b/Core/NativeClient/WebGPU/Shaders/UserInterfaceShader.wgsl
@@ -17,6 +17,7 @@ struct PerSceneData {
 	color: vec4f,
 	viewportWidth: f32,
 	viewportHeight: f32,
+	deltaTime: f32,
 };
 
 @group(0) @binding(0)

--- a/Core/NativeClient/WebGPU/UniformBuffer.lua
+++ b/Core/NativeClient/WebGPU/UniformBuffer.lua
@@ -15,13 +15,14 @@ local UniformBuffer = {
 		// See https://gpuweb.github.io/gpuweb/wgsl/#address-space-layout-constraints
 		// Layouts must match the structs defined in the shaders
 		typedef struct PerSceneData {
-			Matrix4D view;
-			Matrix4D perspectiveProjection;
-			float color[4];
-			float viewportWidth;
-			float viewportHeight;
+			Matrix4D view; // 64
+			Matrix4D perspectiveProjection; // 128
+			float color[4]; // 144
+			float viewportWidth; // 148
+			float viewportHeight; // 152
+			float deltaTime; // 156
 			// Padding needs to be updated whenever the struct changes!
-			uint8_t padding[6];
+			float padding; // 160
 		} scenewide_uniform_t;
 		typedef struct PerMaterialData {
 			float materialOpacity; // 4


### PR DESCRIPTION
The first frame is set to zero so that animation state updates are effectively a NOOP (to prevent potential animation glitches).

---

First part of a basic animation system, split into multiple PRs since there's again too much scope creep.