### PR TITLE
Fix an oversight in the renderer's update loop

### DIFF
--- a/Core/NativeClient/Renderer.lua
+++ b/Core/NativeClient/Renderer.lua
@@ -194,7 +194,7 @@ function Renderer:RenderNextFrame(deltaTime)
 			local material = self.supportedMaterials[materialIndex]
 			-- Should skip this if there aren't any meshes (wasteful to switch for no reason)?
 			RenderPassEncoder:SetPipeline(renderPass, material.assignedRenderingPipeline.wgpuPipeline)
-			for _, mesh in ipairs(self.meshes) do
+			for _, mesh in ipairs(meshes) do
 				for index, animation in ipairs(mesh.keyframeAnimations) do
 					animation:UpdateWithDeltaTime(deltaTime / 10E5)
 				end


### PR DESCRIPTION
This actually causes meshes to be rendered with the wrong material settings, which "accidentally" works if they're using the same rendering pipeline (as they originally did). After substantially changing the water material's rendering backend, however,  it lead to a crash because the regular materials don't support texture arrays.