### PR TITLE
Fix a flaky test for the WebGPU renderer

### DIFF
--- a/Core/NativeClient/WebGPU/Mesh.lua
+++ b/Core/NativeClient/WebGPU/Mesh.lua
@@ -2,7 +2,9 @@ local UnlitMeshMaterial = require("Core.NativeClient.WebGPU.Materials.UnlitMeshM
 
 local uuid = require("uuid")
 
-local Mesh = {}
+local Mesh = {
+	NUM_BUFFERS_PER_MESH = 5, -- Positions, indices, colors, diffuse UVs, normals
+}
 
 function Mesh:Construct(name)
 	local globallyUniqueID = uuid.createMersenneTwistedUUID() -- Might be overkill, but oh well...

--- a/Tests/NativeClient/Renderer.spec.lua
+++ b/Tests/NativeClient/Renderer.spec.lua
@@ -433,13 +433,16 @@ describe("Renderer", function()
 			it("should remove all existing meshes from the scene", function()
 				local scene = require("Core.NativeClient.DebugDraw.Scenes.wgpu")
 				Renderer:LoadSceneObjects(scene)
-				assertEquals(#Renderer.meshes, 9)
+				assertEquals(#Renderer.meshes, #scene.meshes)
 
-				-- A bit sketchy, but oh well... Better: Track wgpu calls (again)? Maybe later, seems redundant
-				_G.assertCallsFunction(function()
-					Renderer:ResetScene()
-				end, Renderer.DestroyMeshGeometry, 42)
-				assertEquals(#Renderer.meshes, 0)
+				etrace.clear()
+				Renderer:ResetScene()
+				local events = etrace.filter()
+
+				assertEquals(#events, #scene.meshes * Mesh.NUM_BUFFERS_PER_MESH)
+				for index = 1, #scene.meshes * Mesh.NUM_BUFFERS_PER_MESH, 1 do
+					assertEquals(events[index].name, "GPU_BUFFER_DESTROY")
+				end
 			end)
 
 			it("should reset the scene lighting to its default values", function()


### PR DESCRIPTION
This causes sporadic CI failures because the function call detection is wonky. It's also outdated since each mesh now requires five buffers and not three, so a bit of generalization may be needed here. Still not great, but should at least reliably pass.