### PR TITLE
Add support for lightmap textures to the WebGPU renderer

### DIFF
--- a/Core/FileFormats/RagnarokGND.lua
+++ b/Core/FileFormats/RagnarokGND.lua
@@ -770,6 +770,21 @@ function RagnarokGND:ComputeFlatFaceNormalRight(gridU, gridV)
 	return rightFaceNormal
 end
 
+function RagnarokGND:GenerateLightmapTextureImage()
+	-- Should replace with a power-of-two texture containing the actual lightmap slices
+	local textureFilePath = path.join("Core", "NativeClient", "Assets", "DebugTexture256.png")
+	local pngFileContents = C_FileSystem.ReadFile(textureFilePath)
+
+	local rgbaImageBytes, width, height = C_ImageProcessing.DecodeFileContents(pngFileContents)
+	local placeholderLightmapTexture = {
+		rgbaImageBytes = rgbaImageBytes,
+		width = width,
+		height = height,
+	}
+
+	return placeholderLightmapTexture
+end
+
 ffi.cdef(RagnarokGND.cdefs)
 
 return RagnarokGND

--- a/Core/FileFormats/RagnarokGND.lua
+++ b/Core/FileFormats/RagnarokGND.lua
@@ -174,6 +174,8 @@ function RagnarokGND:DecodeTexturePaths()
 
 		local groundMeshSection = Mesh("GroundMeshSection" .. textureIndex)
 		groundMeshSection.material = GroundMeshMaterial("GroundMeshSection" .. textureIndex .. "Material")
+		-- Should preallocate based on observed sizes here? (same as for the other buffers)
+		groundMeshSection.lightmapTextureCoords = {}
 		table_insert(self.groundMeshSections, groundMeshSection)
 	end
 end
@@ -450,6 +452,16 @@ function RagnarokGND:GenerateSurfaceGeometry(surfaceConstructionInfo)
 	table_insert(mesh.diffuseTextureCoords, surface.uvs.top_left_v)
 	table_insert(mesh.diffuseTextureCoords, surface.uvs.top_right_u)
 	table_insert(mesh.diffuseTextureCoords, surface.uvs.top_right_v)
+
+	local lightmapTextureCoords = self:ComputeLightmapTextureCoords(surface.lightmap_slice_id)
+	table_insert(mesh.lightmapTextureCoords, lightmapTextureCoords.bottomLeftU)
+	table_insert(mesh.lightmapTextureCoords, lightmapTextureCoords.bottomLeftV)
+	table_insert(mesh.lightmapTextureCoords, lightmapTextureCoords.bottomRightU)
+	table_insert(mesh.lightmapTextureCoords, lightmapTextureCoords.bottomRightV)
+	table_insert(mesh.lightmapTextureCoords, lightmapTextureCoords.topLeftU)
+	table_insert(mesh.lightmapTextureCoords, lightmapTextureCoords.topLeftV)
+	table_insert(mesh.lightmapTextureCoords, lightmapTextureCoords.topRightU)
+	table_insert(mesh.lightmapTextureCoords, lightmapTextureCoords.topRightV)
 
 	if surfaceConstructionInfo.facing == RagnarokGND.SURFACE_DIRECTION_UP then
 		local flatFaceNormalLeft = self:ComputeFlatFaceNormalLeft(gridU, gridV)
@@ -783,6 +795,20 @@ function RagnarokGND:GenerateLightmapTextureImage()
 	}
 
 	return placeholderLightmapTexture
+end
+
+function RagnarokGND:ComputeLightmapTextureCoords(lightmapSliceID)
+	-- Should replace this with the actual lightmap coordinates (to be computed)
+	return {
+		bottomLeftU = 0,
+		bottomLeftV = 0,
+		bottomRightU = 0,
+		bottomRightV = 0,
+		topLeftU = 0,
+		topLeftV = 0,
+		topRightU = 0,
+		topRightV = 0,
+	}
 end
 
 ffi.cdef(RagnarokGND.cdefs)

--- a/Core/FileFormats/RagnarokMap.lua
+++ b/Core/FileFormats/RagnarokMap.lua
@@ -88,6 +88,7 @@ function RagnarokMap:LoadTerrainGeometry(mapID)
 	local gnd = self.gnd
 
 	local groundMeshSections = gnd:GenerateGroundMeshSections()
+	local sharedLightmapTextureImage = gnd:GenerateLightmapTextureImage()
 	for sectionID, groundMeshSection in pairs(groundMeshSections) do
 		local texturePath = "texture/" .. gnd.diffuseTexturePaths[sectionID]
 		local normalizedTextureImagePath = RagnarokGRF:DecodeFileName(texturePath)
@@ -106,6 +107,9 @@ function RagnarokMap:LoadTerrainGeometry(mapID)
 			width = width,
 			height = height,
 		}
+
+		-- Should only upload once and bind the same texture?
+		groundMeshSection.lightmapTextureImage = sharedLightmapTextureImage
 	end
 
 	return groundMeshSections

--- a/Core/NativeClient/Renderer.lua
+++ b/Core/NativeClient/Renderer.lua
@@ -563,6 +563,19 @@ function Renderer:UploadMeshGeometry(mesh)
 	printf("Uploading geometry: %d surface normals (%s)", normalCount, filesize(normalBufferSize))
 	local surfaceNormalsBuffer = Buffer:CreateVertexBuffer(self.wgpuDevice, mesh.surfaceNormals)
 
+	if rawget(mesh, "lightmapTextureCoords") then
+		local lightmapTextureCoordsCount = #mesh.lightmapTextureCoords / 2
+		local lightmapTextureCoordsBufferSize = #mesh.lightmapTextureCoords * ffi.sizeof("float")
+		printf(
+			"Uploading geometry: %d lightmap texture coordinates (%s)",
+			lightmapTextureCoordsCount,
+			filesize(lightmapTextureCoordsBufferSize)
+		)
+		local lightmapTextureCoordinatesBuffer = Buffer:CreateVertexBuffer(self.wgpuDevice, mesh.lightmapTextureCoords)
+
+		mesh.lightmapTexCoordsBuffer = lightmapTextureCoordinatesBuffer
+	end
+
 	mesh.vertexBuffer = vertexBuffer
 	mesh.colorBuffer = vertexColorsBuffer
 	mesh.indexBuffer = triangleIndicesBuffer
@@ -636,6 +649,7 @@ function Renderer:DestroyMeshGeometry(mesh)
 	Buffer:Destroy(rawget(mesh, "colorBuffer"))
 	Buffer:Destroy(rawget(mesh, "indexBuffer"))
 	Buffer:Destroy(rawget(mesh, "diffuseTexCoordsBuffer"))
+	Buffer:Destroy(rawget(mesh, "lightmapTexCoordsBuffer"))
 	Buffer:Destroy(rawget(mesh, "surfaceNormalsBuffer"))
 
 	self.meshes = {}

--- a/Core/NativeClient/Renderer.lua
+++ b/Core/NativeClient/Renderer.lua
@@ -429,6 +429,13 @@ function Renderer:DrawMesh(renderPass, mesh)
 		self.dummyTextureMaterial:UpdateMaterialPropertiesUniform() -- Wasteful, should only do it once?
 	end
 
+	if rawget(mesh.material, "lightmapTexture") then
+		-- This binding slot is usually reserved for instance transforms, but they aren't needed for the terrain
+		RenderPassEncoder:SetBindGroup(renderPass, 2, mesh.material.lightmapTextureBindGroup, 0, nil)
+		local lightmapTexCoordsBufferSize = #mesh.lightmapTextureCoords * ffi.sizeof("float") or GPU.MAX_VERTEX_COUNT
+		RenderPassEncoder:SetVertexBuffer(renderPass, 4, mesh.lightmapTexCoordsBuffer, 0, lightmapTexCoordsBufferSize)
+	end
+
 	local instanceCount = 1
 	local firstVertexIndex = 0
 	local firstInstanceIndex = 0

--- a/Core/NativeClient/Renderer.lua
+++ b/Core/NativeClient/Renderer.lua
@@ -70,9 +70,11 @@ local Renderer = {
 		INVALID_INDEX_BUFFER = "Cannot upload geometry with invalid index buffer",
 		INVALID_COLOR_BUFFER = "Cannot upload geometry with invalid color buffer",
 		INVALID_UV_BUFFER = "Cannot upload geometry with invalid diffuse texture coordinates buffer",
+		INVALID_LIGHTMAP_UV_BUFFER = "Cannot upload geometry with invalid lightmap texture coordinates buffer",
 		INVALID_NORMAL_BUFFER = "Cannot upload geometry with invalid normal buffer",
 		INCOMPLETE_COLOR_BUFFER = "Cannot upload geometry with missing or incomplete vertex colors",
 		INCOMPLETE_UV_BUFFER = "Cannot upload geometry with missing or incomplete diffuse texture coordinates ",
+		INCOMPLETE_LIGHTMAP_UV_BUFFER = "Cannot upload geometry with missing or incomplete lightmap texture coordinates ",
 		INVALID_MATERIAL = "Invalid material assigned to mesh",
 		INCOMPLETE_NORMAL_BUFFER = "Cannot upload geometry with missing or incomplete surface normals ",
 	},
@@ -605,17 +607,26 @@ function Renderer:ValidateGeometry(mesh)
 		error(self.errorStrings.INCOMPLETE_NORMAL_BUFFER, 0)
 	end
 
-	if not mesh.diffuseTextureCoords then
-		return
+	if mesh.diffuseTextureCoords then
+		local diffuseTextureCoordsCount = #mesh.diffuseTextureCoords / 2
+		if (diffuseTextureCoordsCount * 2) % 2 ~= 0 then
+			error(self.errorStrings.INVALID_UV_BUFFER, 0)
+		end
+
+		if vertexCount ~= diffuseTextureCoordsCount then
+			error(self.errorStrings.INCOMPLETE_UV_BUFFER, 0)
+		end
 	end
 
-	local diffuseTextureCoordsCount = #mesh.diffuseTextureCoords / 2
-	if (diffuseTextureCoordsCount * 2) % 2 ~= 0 then
-		error(self.errorStrings.INVALID_UV_BUFFER, 0)
-	end
+	if rawget(mesh, "lightmapTextureCoords") then
+		local lightmapTextureCoordsCount = #mesh.lightmapTextureCoords / 2
+		if (lightmapTextureCoordsCount * 2) % 2 ~= 0 then
+			error(self.errorStrings.INVALID_LIGHTMAP_UV_BUFFER, 0)
+		end
 
-	if vertexCount ~= diffuseTextureCoordsCount then
-		error(self.errorStrings.INCOMPLETE_UV_BUFFER, 0)
+		if vertexCount ~= lightmapTextureCoordsCount then
+			error(self.errorStrings.INCOMPLETE_LIGHTMAP_UV_BUFFER, 0)
+		end
 	end
 end
 

--- a/Core/NativeClient/WebGPU/GPU.lua
+++ b/Core/NativeClient/WebGPU/GPU.lua
@@ -114,9 +114,9 @@ function GPU:RequestLogicalDevice(adapter, options)
 				maxTextureDimension2D = Texture.MAX_TEXTURE_DIMENSION,
 				maxTextureDimension3D = 0,
 				maxTextureArrayLayers = 1, -- For the depth/stencil texture
-				maxVertexAttributes = 4, -- Vertex positions, vertex colors, diffuse texture UVs, normals
-				maxVertexBuffers = 4, -- Vertex positions, vertex colors, diffuse texture UVs, normals
-				maxInterStageShaderComponents = 8, -- #(vec3f color, vec2f diffuseTextureCoords, float alpha), normal(vec3f)
+				maxVertexAttributes = 5, -- Vertex positions, vertex colors, diffuse UVs, normals, lightmap UVs
+				maxVertexBuffers = 5, -- Vertex positions, vertex colors, diffuse UVs, normals, lightmap UVs
+				maxInterStageShaderComponents = 10, -- #(vec3f color, vec2f diffuseTextureCoords, float alpha), normal(vec3f), lightmapUV(vec2f)
 				maxBufferSize = GPU.MAX_BUFFER_SIZE, -- DEFAULT
 				maxVertexBufferArrayStride = 20, -- #(Rml::Vertex)
 				maxBindGroups = 3, -- Camera, material, transforms

--- a/Core/NativeClient/WebGPU/Materials/GroundMeshMaterial.lua
+++ b/Core/NativeClient/WebGPU/Materials/GroundMeshMaterial.lua
@@ -16,6 +16,8 @@ function GroundMeshMaterial:Construct(...)
 end
 
 function GroundMeshMaterial:AssignLightmapTexture(texture)
+	-- It's probably safe to use the diffuse bind group layout here, at least for now?
+	self.lightmapTextureBindGroup = self:CreateMaterialPropertiesBindGroup(texture)
 	self.lightmapTexture = texture
 end
 

--- a/Core/NativeClient/WebGPU/Materials/GroundMeshMaterial.lua
+++ b/Core/NativeClient/WebGPU/Materials/GroundMeshMaterial.lua
@@ -15,6 +15,10 @@ function GroundMeshMaterial:Construct(...)
 	return self.super.Construct(self, ...)
 end
 
+function GroundMeshMaterial:AssignLightmapTexture(texture)
+	self.lightmapTexture = texture
+end
+
 class("GroundMeshMaterial", GroundMeshMaterial)
 extend(GroundMeshMaterial, InvisibleBaseMaterial)
 

--- a/Core/NativeClient/WebGPU/Materials/InvisibleBaseMaterial.lua
+++ b/Core/NativeClient/WebGPU/Materials/InvisibleBaseMaterial.lua
@@ -47,6 +47,10 @@ function InvisibleBaseMaterial:AssignDiffuseTexture(texture, wgpuTexture)
 	self.diffuseTexture = texture
 end
 
+function InvisibleBaseMaterial:AssignLightmapTexture(texture, wgpuTexture)
+	error("Lightmap textures aren't yet supported by this material", 0)
+end
+
 function InvisibleBaseMaterial:UpdateMaterialPropertiesUniform()
 	-- Should only send if the data has actually changed? (optimize later)
 	self.materialPropertiesUniform.data.diffuseRed = self.diffuseColor.red

--- a/Core/NativeClient/WebGPU/Mesh.lua
+++ b/Core/NativeClient/WebGPU/Mesh.lua
@@ -3,7 +3,7 @@ local UnlitMeshMaterial = require("Core.NativeClient.WebGPU.Materials.UnlitMeshM
 local uuid = require("uuid")
 
 local Mesh = {
-	NUM_BUFFERS_PER_MESH = 5, -- Positions, indices, colors, diffuse UVs, normals
+	MAX_BUFFER_COUNT_PER_MESH = 6, -- Positions, indices, colors, diffuse UVs, normals, lightmap UVs
 }
 
 function Mesh:Construct(name)

--- a/Core/NativeClient/WebGPU/Pipelines/BasicTriangleDrawingPipeline.lua
+++ b/Core/NativeClient/WebGPU/Pipelines/BasicTriangleDrawingPipeline.lua
@@ -165,11 +165,23 @@ function BasicTriangleDrawingPipeline:CreateVertexBufferLayout()
 		stepMode = ffi.C.WGPUVertexStepMode_Vertex,
 	})
 
-	return new("WGPUVertexBufferLayout[?]", 4, {
+	local lightmapTexCoordsLayout = new("WGPUVertexBufferLayout", {
+		attributeCount = 1, -- UV
+		attributes = new("WGPUVertexAttribute", {
+			shaderLocation = 4, -- Pass as 5th argument
+			format = ffi.C.WGPUVertexFormat_Float32x2, -- Vector2D (float) = UV coords
+			offset = 0,
+		}),
+		arrayStride = 2 * sizeof("float"), -- sizeof(Vector2D) = uv
+		stepMode = ffi.C.WGPUVertexStepMode_Vertex,
+	})
+
+	return new("WGPUVertexBufferLayout[?]", 5, {
 		vertexPositionsLayout,
 		vertexColorsLayout,
 		diffuseTexCoordsLayout,
 		surfaceNormalsLayout,
+		lightmapTexCoordsLayout,
 	})
 end
 

--- a/Core/NativeClient/WebGPU/Pipelines/GroundMeshDrawingPipeline.lua
+++ b/Core/NativeClient/WebGPU/Pipelines/GroundMeshDrawingPipeline.lua
@@ -20,7 +20,7 @@ function GroundMeshDrawingPipeline:Construct(wgpuDeviceHandle, textureFormatID)
 	local sharedShaderModule = self:CreateShaderModule(wgpuDeviceHandle)
 	local renderPipelineDescriptor = new("WGPURenderPipelineDescriptor", {
 		vertex = {
-			bufferCount = 4, -- Vertex positions, colors, diffuse UVs, normals
+			bufferCount = 5, -- Vertex positions, colors, diffuse UVs, normals, lightmap UVs
 			module = sharedShaderModule,
 			entryPoint = "vs_main",
 			constantCount = 0,
@@ -82,10 +82,11 @@ function GroundMeshDrawingPipeline:Construct(wgpuDeviceHandle, textureFormatID)
 
 	-- Configure resource layout for the vertex shader
 	local pipelineLayoutDescriptor = new("WGPUPipelineLayoutDescriptor", {
-		bindGroupLayoutCount = 2,
-		bindGroupLayouts = new("WGPUBindGroupLayout[?]", 2, {
+		bindGroupLayoutCount = 3,
+		bindGroupLayouts = new("WGPUBindGroupLayout[?]", 3, {
 			UniformBuffer.cameraBindGroupLayout,
 			UniformBuffer.materialBindGroupLayout,
+			UniformBuffer.materialBindGroupLayout, -- Re-used for lightmaps
 		}),
 	})
 

--- a/Tests/FileFormats/RagnarokGND.spec.lua
+++ b/Tests/FileFormats/RagnarokGND.spec.lua
@@ -566,11 +566,18 @@ describe("RagnarokGND", function()
 					triangleConnections = {},
 					diffuseTextureCoords = {},
 					surfaceNormals = {},
+					lightmapTextureCoords = {},
 				},
 			}
 			local sections = gnd:GenerateGroundMeshSections()
 			assertEquals(#sections, 1) -- Index starts at zero
 			assertEquals(table.count(sections), 1)
+
+			-- Remove this once the actual lightmap UVs are being computed
+			for index, section in ipairs(sections) do
+				section.lightmapTextureCoords = nil -- No need to snapshot placeholder UVs
+			end
+
 			local json = require("json")
 			local jsonDump = json.prettier(sections)
 			-- Leaving this here because the snapshot likely needs to be recreated once lightmaps/normals are needed

--- a/Tests/NativeClient/Renderer.spec.lua
+++ b/Tests/NativeClient/Renderer.spec.lua
@@ -330,6 +330,26 @@ describe("Renderer", function()
 			assertThrows(uploadIncompleteMeshGeometry, expectedErrorMessage)
 		end)
 
+		it("should throw if the geometry contains an insufficient number of lightmap texture coordinates", function()
+			local mesh = table.copy(planeMesh)
+			mesh.lightmapTextureCoords = { 1, 2, 3 }
+			local expectedErrorMessage = Renderer.errorStrings.INVALID_LIGHTMAP_UV_BUFFER
+			local function uploadIncompleteMeshGeometry()
+				Renderer:UploadMeshGeometry(mesh)
+			end
+			assertThrows(uploadIncompleteMeshGeometry, expectedErrorMessage)
+		end)
+
+		it("should throw if the geometry contains more vertex positions than lightmap texture coordinates", function()
+			local mesh = table.copy(planeMesh)
+			mesh.lightmapTextureCoords = {}
+			local expectedErrorMessage = Renderer.errorStrings.INCOMPLETE_LIGHTMAP_UV_BUFFER
+			local function uploadIncompleteMeshGeometry()
+				Renderer:UploadMeshGeometry(mesh)
+			end
+			assertThrows(uploadIncompleteMeshGeometry, expectedErrorMessage)
+		end)
+
 		it("should skip geometry that contains no vertex position", function()
 			local mesh = table.copy(planeMesh)
 			mesh.vertexPositions = {}


### PR DESCRIPTION
Very basic and using some placeholders for the lightmap texture and UVs. Needs adjustments to the sampling method, as well.

---

Resolves #131.