### PR TITLE
Fix the alpha channel for generated GAT images

### DIFF
--- a/Tests/Tools/RagnarokTools.spec.lua
+++ b/Tests/Tools/RagnarokTools.spec.lua
@@ -92,7 +92,7 @@ describe("RagnarokTools", function()
 
 	describe("ExportCollisionMapFromGAT", function()
 		it("should export the GAT terrain data in a human-readable format if a valid GAT buffer is passed", function()
-			local expectedChecksum = "30acbeac20c84b513f45455f1acfacbdc4bca67d65d2627bcbd84e243034ba0b"
+			local expectedChecksum = "315ad7d3a93849ec6fbb7786cd739e8237ead08b2cb1530bf6370f9cfe9c873b"
 
 			local gatFileContents = C_FileSystem.ReadFile(path.join("Tests", "Fixtures", "v0102.gat"))
 			RagnarokTools:ExportCollisionMapFromGAT(gatFileContents, uv.cwd())
@@ -108,7 +108,7 @@ describe("RagnarokTools", function()
 
 	describe("ExportTerrainMapFromGAT", function()
 		it("should export the GAT terrain data in a human-readable format if a valid GAT buffer is passed", function()
-			local expectedChecksum = "9178031d79bc95c68368abbd870768fc27b6e2603f1b2975079b714260c85684"
+			local expectedChecksum = "348cb14b08edd6e41f7c6eee094b033020d397d8d28bc91ac12f3dc98da6fe1b"
 
 			local gatFileContents = C_FileSystem.ReadFile(path.join("Tests", "Fixtures", "v0102.gat"))
 			RagnarokTools:ExportTerrainMapFromGAT(gatFileContents, uv.cwd())
@@ -124,7 +124,7 @@ describe("RagnarokTools", function()
 
 	describe("ExportHeightMapFromGAT", function()
 		it("should export the GAT terrain data in a human-readable format if a valid GAT buffer is passed", function()
-			local expectedChecksum = "1f4328f8de834ddbdccb038ea4e95ee8a1b4cbfe6df0d09d3b19fc4af8acfa99"
+			local expectedChecksum = "e3ab51a50d93a00bd28b22264e52e983a375dbbe7a87ecdd0c9a0c99ebf541e4"
 
 			local gatFileContents = C_FileSystem.ReadFile(path.join("Tests", "Fixtures", "v0102.gat"))
 			RagnarokTools:ExportHeightMapFromGAT(gatFileContents, uv.cwd())

--- a/Tools/RagnarokTools.lua
+++ b/Tools/RagnarokTools.lua
@@ -253,7 +253,7 @@ function RagnarokTools:ExportHeightMapFromGAT(gatFileContents, outputDirectory)
 			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", relativeHeight * 255), 1)
 			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", relativeHeight * 255), 1)
 			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", relativeHeight * 255), 1)
-			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", 0), 1)
+			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", 255), 1)
 		end
 	end
 
@@ -287,7 +287,7 @@ function RagnarokTools:ExportCollisionMapFromGAT(gatFileContents, outputDirector
 			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", (isBlocked and 0 or 1) * 255), 1)
 			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", (isBlocked and 0 or 1) * 255), 1)
 			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", (isBlocked and 0 or 1) * 255), 1)
-			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", 0), 1)
+			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", 255), 1)
 		end
 	end
 
@@ -337,7 +337,7 @@ function RagnarokTools:ExportTerrainMapFromGAT(gatFileContents, outputDirectory)
 			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", pixelColor.red), 1)
 			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", pixelColor.green * 255), 1)
 			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", pixelColor.blue * 255), 1)
-			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", 0), 1)
+			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", 255), 1)
 		end
 	end
 


### PR DESCRIPTION
I think this used to be ignored, but now it isn't so the final image will be fully transparent. Tests didn't catch it either, apparently.