### PR TITLE
Rework the GAT heightmap image generation script

### DIFF
--- a/Tools/RagnarokTools.lua
+++ b/Tools/RagnarokTools.lua
@@ -237,22 +237,25 @@ function RagnarokTools:ExportHeightMapFromGAT(gatFileContents, outputDirectory)
 	local rgbaImageBytes = buffer.new(gat.mapU * gat.mapV * 4)
 
 	local maxObservedAltitude = 0
+	local minObservedAltitude = math.huge
 	for v = 1, gat.mapV do
 		for u = 1, gat.mapU do
 			local altitude = gat:GetTerrainAltitudeAt(u, v)
 			maxObservedAltitude = math.max(maxObservedAltitude, altitude)
+			minObservedAltitude = math.min(minObservedAltitude, altitude)
 		end
 	end
 
-	local normalizationFactor = 1 - math.floor(255 / maxObservedAltitude)
+	local observedAltitudeRange = maxObservedAltitude - minObservedAltitude
 
 	for v = 1, gat.mapV do
 		for u = 1, gat.mapU do
 			local altitude = gat:GetTerrainAltitudeAt(u, v)
-			local relativeHeight = math.floor(altitude * normalizationFactor)
-			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", relativeHeight * 255), 1)
-			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", relativeHeight * 255), 1)
-			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", relativeHeight * 255), 1)
+			local relativeAltitude = (altitude - minObservedAltitude) / observedAltitudeRange
+			local normalizedAltitude = math.floor(relativeAltitude * 255)
+			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", normalizedAltitude), 1)
+			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", normalizedAltitude), 1)
+			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", normalizedAltitude), 1)
 			rgbaImageBytes:putcdata(ffi.new("uint8_t[1]", 255), 1)
 		end
 	end


### PR DESCRIPTION
The previous approach to normalization is nonsensical and fails when encountering certain values, including those used by the test fixtures. This manifests differently on the M1 runner (using ARM64), which is why the CI kept failing even after the last few fixes. Not sure if this normalization method is the best choice, as the contrast is quite low in certain maps (e.g., prontera). But at least it shouldn't generate NaN/invalid results.