### PR TITLE
Improve the renderer's handling of surface status changes

### DIFF
--- a/Core/NativeClient/Renderer.lua
+++ b/Core/NativeClient/Renderer.lua
@@ -216,6 +216,7 @@ function Renderer:RenderNextFrame(deltaTime)
 	if not nextTextureView then
 		-- Recoverable error, but this frame is probably beyond saving as reconfiguring the surface takes time
 		printf(transform.yellow(Renderer.errorStrings.TEXTURE_ACQUISITION_FAILED), failureReason)
+		self.backingSurface:UpdateConfiguration()
 		return 0, 0, 0, 0
 	end
 

--- a/Core/NativeClient/WebGPU/Surface.lua
+++ b/Core/NativeClient/WebGPU/Surface.lua
@@ -61,6 +61,13 @@ function Surface:UpdateConfiguration()
 	surfaceConfiguration.presentMode = ffi.C.WGPUPresentMode_Fifo
 
 	webgpu.bindings.wgpu_surface_configure(self.wgpuSurface, surfaceConfiguration)
+
+	printf(
+		"Surface configuration changed: Frame buffer size is now %dx%d (preferred texture format: %d)",
+		viewportWidth,
+		viewportHeight,
+		tonumber(preferredTextureFormat)
+	)
 end
 
 function Surface:AcquireTextureView()

--- a/Tests/NativeClient/WebGPU/Surface.spec.lua
+++ b/Tests/NativeClient/WebGPU/Surface.spec.lua
@@ -1,0 +1,39 @@
+local Surface = require("Core.NativeClient.WebGPU.Surface")
+
+local ffi = require("ffi")
+
+describe("Surface", function()
+	describe("ValidateTextureStatus", function()
+		it("should throw if the texture status change can't be handled cleanly", function()
+			assertThrows(function()
+				Surface:ValidateTextureStatus(ffi.C.WGPUSurfaceGetCurrentTextureStatus_Force32)
+			end, Surface.errorStrings.UNKNOWN_TEXTURE_STATUS)
+
+			assertThrows(function()
+				Surface:ValidateTextureStatus(ffi.C.WGPUSurfaceGetCurrentTextureStatus_DeviceLost)
+			end, Surface.errorStrings.GPU_DEVICE_LOST)
+
+			assertThrows(function()
+				Surface:ValidateTextureStatus(ffi.C.WGPUSurfaceGetCurrentTextureStatus_OutOfMemory)
+			end, Surface.errorStrings.GPU_MEMORY_EXHAUSTED)
+		end)
+
+		it("should fail if the status indicates that the surface needs to be reconfigured", function()
+			assertFailure(function()
+				return Surface:ValidateTextureStatus(ffi.C.WGPUSurfaceGetCurrentTextureStatus_Lost)
+			end, Surface.errorStrings.BACKING_SURFACE_LOST)
+
+			assertFailure(function()
+				return Surface:ValidateTextureStatus(ffi.C.WGPUSurfaceGetCurrentTextureStatus_Outdated)
+			end, Surface.errorStrings.BACKING_SURFACE_OUTDATED)
+
+			assertFailure(function()
+				return Surface:ValidateTextureStatus(ffi.C.WGPUSurfaceGetCurrentTextureStatus_Timeout)
+			end, Surface.errorStrings.BACKING_SURFACE_TIMEOUT)
+		end)
+
+		it("should return true if the status indicates that the texture is ready to use", function()
+			assertTrue(Surface:ValidateTextureStatus(ffi.C.WGPUSurfaceGetCurrentTextureStatus_Success))
+		end)
+	end)
+end)

--- a/Tests/unit-test.lua
+++ b/Tests/unit-test.lua
@@ -43,6 +43,7 @@ local specFiles = {
 	"Tests/NativeClient/WebGPU/UnlitMeshMaterial.spec.lua",
 	"Tests/NativeClient/WebGPU/WaterSurfaceMaterial.spec.lua",
 	"Tests/NativeClient/WebGPU/UserInterfaceMaterial.spec.lua",
+	"Tests/NativeClient/WebGPU/Surface.spec.lua",
 	"Tests/NativeClient/WebGPU/Texture.spec.lua",
 	"Tests/WorldServer/C_ServerHealth.spec.lua",
 	"Tests/WorldServer/WorldServer.spec.lua",


### PR DESCRIPTION
Recoverable errors now re-configure the surface and continue to use it after a single skipped frame. Fatal errors have better error messages, although they will still crash the application (can't be helped, I think). This should resolve #245, as far as I can tell.