### PR TITLE
Add a new CLI switch for profiling the startup time

### DIFF
--- a/Core/NativeClient/NativeClient.lua
+++ b/Core/NativeClient/NativeClient.lua
@@ -394,6 +394,10 @@ function NativeClient:LoadSceneByID(globallyUniqueSceneID)
 
 	local map = RagnarokMap(globallyUniqueSceneID, grfFileSystem) or DebugScene(globallyUniqueSceneID)
 	Renderer:LoadSceneObjects(map)
+
+	if self.isProfilingStartupTime then
+		os.exit(0, true) -- Job's done
+	end
 end
 
 function NativeClient:LoadScenesOneByOne(delayInMilliseconds)

--- a/client.lua
+++ b/client.lua
@@ -16,6 +16,8 @@ elseif arg[1] == "--stresstest" then
 		NativeClient:LoadScenesOneByOne(arg[2])
 	end)
 	_G.arg[1] = nil -- Don't try to load it as a scene
+elseif arg[2] == "--profile" then
+	NativeClient.isProfilingStartupTime = true
 end
 
 local mapID = arg[1]


### PR DESCRIPTION
In order to get accurate profiling results, the render loop needs to be stopped immediately after loading the given scene.