### PR TITLE
Discard transparent background pixels in the fragment shader instead of a separate CPU pre-processing step

### DIFF
--- a/Core/NativeClient/WebGPU/Shaders/TerrainGeometryShader.wgsl
+++ b/Core/NativeClient/WebGPU/Shaders/TerrainGeometryShader.wgsl
@@ -135,13 +135,22 @@ fn vs_main(in: VertexInput) -> VertexOutput {
 	return out;
 }
 
+// Magenta background pixels should be discarded (but pre-processing on the CPU is expensive)
+fn isTransparentBackgroundPixel(diffuseTextureColor : vec4f) -> bool {
+	return (diffuseTextureColor.r >= 254/255 && diffuseTextureColor.g <= 3/255 && diffuseTextureColor.b >= 254/255);
+}
+
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4f {
 	let textureCoords = in.diffuseTextureCoords;
-	let diffuseTextureColor = textureSample(diffuseTexture, diffuseTextureSampler, textureCoords);
+	var diffuseTextureColor = textureSample(diffuseTexture, diffuseTextureSampler, textureCoords);
 	let normal = normalize(in.surfaceNormal);
 	let sunlightColor = uPerSceneData.directionalLightColor.rgb;
 	let ambientColor = uPerSceneData.ambientLight.rgb;
+
+	if (isTransparentBackgroundPixel(diffuseTextureColor)) {
+		diffuseTextureColor.a = 0.0;
+	}
 
 	let lightmapTexCoords = in.lightmapTextureCoords;
 	var lightmapTextureColor = textureSample(lightmapTexture, lightmapTextureSampler, lightmapTexCoords);


### PR DESCRIPTION
This reduces the loading times, at the cost of having to perform more checks on the GPU. I highly doubt GPU usage will be an issue however, whereas loading times are very painful in general.

The drawback here is that if a single texture was to be reused many times, it would incur a runtime cost for each instance, whereas pre-processing has a startup cost shared between all instances. But I doubt it's relevant here, and there's no mechanism to reuse resources currently, anyway.

---

Before this change:

* Loading `yuno` takes about **2.1 seconds**
* Loading `icecastle` takes about **2.2 seconds**
* Loading `pay_dun00` takes about **1.1 seconds**
* Loading `schg_dun01` takes about **2.4 seconds**
* Loading `prontera` takes about **0.9 seconds**

After this change:

* Loading `yuno` takes about **1.5 seconds**
* Loading `icecastle` takes about **1.9 seconds**
* Loading `pay_dun00` takes about **1.1 seconds**
* Loading `schg_dun01` takes about **2.2 seconds**
* Loading `prontera` takes about **0.9 seconds**

The GPU frame time might be slightly higher, but I haven't measured since GPU usage is fairly low anyway.