### PR TITLE
Fix an unintended type conversion in the terrain shader

### DIFF
--- a/Core/NativeClient/WebGPU/Shaders/TerrainGeometryShader.wgsl
+++ b/Core/NativeClient/WebGPU/Shaders/TerrainGeometryShader.wgsl
@@ -137,7 +137,7 @@ fn vs_main(in: VertexInput) -> VertexOutput {
 
 // Magenta background pixels should be discarded (but pre-processing on the CPU is expensive)
 fn isTransparentBackgroundPixel(diffuseTextureColor : vec4f) -> bool {
-	return (diffuseTextureColor.r >= 254/255 && diffuseTextureColor.g <= 3/255 && diffuseTextureColor.b >= 254/255);
+	return (diffuseTextureColor.r >= 254.0/255.0 && diffuseTextureColor.g <= 3.0/255.0 && diffuseTextureColor.b >= 254.0/255.0);
 }
 
 @fragment

--- a/Core/NativeClient/WebGPU/Shaders/TerrainGeometryShader.wgsl
+++ b/Core/NativeClient/WebGPU/Shaders/TerrainGeometryShader.wgsl
@@ -149,7 +149,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
 	let ambientColor = uPerSceneData.ambientLight.rgb;
 
 	if (isTransparentBackgroundPixel(diffuseTextureColor)) {
-		diffuseTextureColor.a = 0.0;
+		discard;
 	}
 
 	let lightmapTexCoords = in.lightmapTextureCoords;


### PR DESCRIPTION
This error was concealed by a recent change to wgpu, where it would automatically convert unsigned integers to floats when it deems it "safe" to do so. Previously, it would've given a validation error here because the hardcoded numbers aren't compiled to floats unless explicitly marked as such.

Apparently, this hidden conversion broke the discard logic, leading to black surfaces being discarded in at least one case (c_tower1). This is because the division doesn't have enough precision if using integers. Being explicit fixes the problem.

Edit: I also noticed the shader isn't actually discarding the fragment, which seems like a silly oversight.