### PR TITLE
Add normalization steps for RSM names and file paths to the RSM and RSW decoders

### DIFF
--- a/Core/FileFormats/RagnarokRSM.lua
+++ b/Core/FileFormats/RagnarokRSM.lua
@@ -1,4 +1,5 @@
 local assertions = require("assertions")
+local iconv = require("iconv")
 local uv = require("uv")
 
 local assert = assert
@@ -186,11 +187,15 @@ function RagnarokRSM:DecodeMeshNode()
 	if self.version >= 2.2 then
 		local numCharactersToRead = reader:GetInt32()
 		mesh.name = reader:GetNullTerminatedString(numCharactersToRead)
+		mesh.name = iconv.convert(mesh.name, "CP949", "UTF-8") or ""
 		numCharactersToRead = reader:GetInt32()
 		mesh.parentNodeName = reader:GetNullTerminatedString(numCharactersToRead)
+		mesh.parentNodeName = iconv.convert(mesh.parentNodeName, "CP949", "UTF-8") or ""
 	else
 		mesh.name = reader:GetNullTerminatedString(40)
+		mesh.name = iconv.convert(mesh.name, "CP949", "UTF-8") or ""
 		mesh.parentNodeName = reader:GetNullTerminatedString(40)
+		mesh.parentNodeName = iconv.convert(mesh.parentNodeName, "CP949", "UTF-8") or ""
 	end
 
 	if self.version >= 2.3 then

--- a/Core/FileFormats/RagnarokRSW.lua
+++ b/Core/FileFormats/RagnarokRSW.lua
@@ -1,4 +1,5 @@
 local ffi = require("ffi")
+local iconv = require("iconv")
 local uv = require("uv")
 
 local tonumber = tonumber
@@ -323,13 +324,13 @@ function RagnarokRSW:DecodeAnimatedProps()
 		objectInfo.unknownMysteryByte = 0
 	end
 
-	objectInfo.name = ffi_string(prop.name)
+	objectInfo.name = iconv.convert(ffi_string(prop.name), "CP949", "UTF-8") or ""
 	objectInfo.animationTypeID = tonumber(prop.animation_type_id)
 	objectInfo.animationSpeedPercentage = tonumber(prop.animation_speed)
 	objectInfo.isSolid = tonumber(prop.block_type_id) == RagnarokRSW.PROP_COLLISION_TYPE_SOLID
 
-	objectInfo.rsmFile = ffi_string(prop.rsm_model_name)
-	objectInfo.rsmNodeName = ffi_string(prop.rsm_node_name)
+	objectInfo.rsmFile = iconv.convert(ffi_string(prop.rsm_model_name), "CP949", "UTF-8") or ""
+	objectInfo.rsmNodeName = iconv.convert(ffi_string(prop.rsm_node_name), "CP949", "UTF-8") or ""
 	objectInfo.normalizedWorldPosition = {
 		x = prop.position.x * RagnarokGND.NORMALIZING_SCALE_FACTOR,
 		y = -1 * prop.position.y * RagnarokGND.NORMALIZING_SCALE_FACTOR,


### PR DESCRIPTION
The files can't be loaded with their gibberish name as GRF paths are normalized on load. Also, it's just inconsistent right now.