### PR TITLE
Add a utility script to dump RSM files as JSON

### DIFF
--- a/Core/FileFormats/RagnarokRSM.lua
+++ b/Core/FileFormats/RagnarokRSM.lua
@@ -1,5 +1,6 @@
 local assertions = require("assertions")
 local iconv = require("iconv")
+local json = require("json")
 local uv = require("uv")
 
 local assert = assert
@@ -426,6 +427,25 @@ function RagnarokRSM:DecodeOptionalBoundingBoxes()
 		assert(boundingBox.unknownFlag == 0, boundingBox.unknownFlag) -- Unsupported, so fail loudly
 		table_insert(self.boundingBoxes, boundingBox)
 	end
+end
+
+function RagnarokRSM:ToJSON()
+	local rsmInfo = {
+		signature = self.signature,
+		version = self.version,
+		animationDurationInMilliseconds = self.animationDurationInMilliseconds,
+		shadingModeID = self.shadingModeID,
+		opacity = self.opacity,
+		animationFPS = self.animationFPS,
+		numAnimationFramesPerCycle = self.numAnimationFramesPerCycle,
+		mysteryBytes = self.mysteryBytes,
+		texturePaths = self.texturePaths,
+		rootNodes = self.rootNodes,
+		meshes = self.meshes,
+		scaleKeyframes = self.scaleKeyframes,
+		boundingBoxes = self.boundingBoxes,
+	}
+	return json.prettier(rsmInfo)
 end
 
 return RagnarokRSM

--- a/Tools/rsm-to-json.lua
+++ b/Tools/rsm-to-json.lua
@@ -1,0 +1,18 @@
+local RagnarokGRF = require("Core.FileFormats.RagnarokGRF")
+local RagnarokRSM = require("Core.FileFormats.RagnarokRSM")
+
+local grf = RagnarokGRF()
+grf:Open("data.grf")
+local rsmFileName = arg[1] or "data/model/프론테라/민가04.rsm"
+
+local rsmFileContents = grf:ExtractFileInMemory(rsmFileName)
+grf:Close()
+
+local rsm = RagnarokRSM()
+rsm:DecodeFileContents(rsmFileContents)
+
+local jsonFileContents = rsm:ToJSON()
+
+local jsonFilePath = path.join("Exports", path.basename(rsmFileName) .. ".json")
+printf("Exporting decoded file contents to %s", jsonFilePath)
+C_FileSystem.WriteFile(jsonFilePath, jsonFileContents)


### PR DESCRIPTION
This doesn't currently work due to a bug in the JSON encoder; it will throw when encountering FFI metatypes and other unexpected value types. After the next runtime update, this problem should no longer exist.