### PR TITLE
Change the default scene clear color to BLACK

### DIFF
--- a/Core/NativeClient/DebugDraw/Color.lua
+++ b/Core/NativeClient/DebugDraw/Color.lua
@@ -7,6 +7,7 @@ local string_sub = string.sub
 local transform_bold = transform.bold
 
 local Color = {
+	BLACK = { red = 0, green = 0, blue = 0 },
 	WHITE = { red = 1, green = 1, blue = 1 },
 	RED = { red = 1, green = 0, blue = 0 },
 	GREEN = { red = 0, green = 1, blue = 0 },

--- a/Core/NativeClient/Renderer.lua
+++ b/Core/NativeClient/Renderer.lua
@@ -48,7 +48,7 @@ local DEFAULT_SUNLIGHT_COLOR = DEFAULT_AMBIENT_COLOR
 local DEFAULT_SUNLIGHT_DIRECTION = { x = 1, y = -1, z = 1 }
 
 local Renderer = {
-	clearColorRGBA = { Color.GREY.red, Color.GREY.green, Color.GREY.blue, 0 },
+	clearColorRGBA = { Color.BLACK.red, Color.BLACK.green, Color.BLACK.blue, 0 },
 	userInterfaceTexturesToMaterial = {},
 	meshes = {},
 	ambientLight = {


### PR DESCRIPTION
The brighter color was useful for debugging, but certain maps are designed to incorporate the background color so it looks wrong.