### PR TITLE
 Fix an oversight in the water types analysis script

### DIFF
--- a/Tools/analyze-water-types.lua
+++ b/Tools/analyze-water-types.lua
@@ -7,13 +7,23 @@ local FileAnalyzer = require("Tools.FileAnalyzer")
 local console = require("console")
 local json = require("json")
 
+local table_insert = table.insert
+
 local grfPath = "data.grf"
 local grf = RagnarokGRF()
 grf:Open(grfPath)
 
 local rswFileList = grf:FindFilesByType("rsw")
 local gndFileList = grf:FindFilesByType("gnd")
-local fileList = { unpack(rswFileList), unpack(gndFileList) }
+local fileList = {}
+
+for index, grfEntry in ipairs(rswFileList) do
+	table_insert(fileList, grfEntry)
+end
+
+for index, grfEntry in ipairs(gndFileList) do
+	table_insert(fileList, grfEntry)
+end
 
 AnimatedWaterPlane.PREALLOCATE_GEOMETRY_BUFFERS = false -- Will run OOM here if preallocating all these buffers
 


### PR DESCRIPTION
The file list should contain both RSW and GND maps, but unpacking tables with duplicate indices doesn't work the same way in Lua as it does in JavaScript. The end result is that only the GND maps are collected as the previously unpacked keys are overwritten.