### PR TITLE
Enable posterization of the lightmap alpha channel

### DIFF
--- a/Core/FileFormats/RagnarokGND.lua
+++ b/Core/FileFormats/RagnarokGND.lua
@@ -821,14 +821,16 @@ function RagnarokGND:GenerateLightmapTextureImage(posterizationLevel)
 				local posterizedRed = bit.rshift(red, posterizationLevel)
 				local posterizedGreen = bit.rshift(green, posterizationLevel)
 				local posterizedBlue = bit.rshift(blue, posterizationLevel)
+				local posterizedAlpha = bit.rshift(alpha, posterizationLevel)
 				posterizedRed = bit.lshift(posterizedRed, posterizationLevel)
 				posterizedGreen = bit.lshift(posterizedGreen, posterizationLevel)
 				posterizedBlue = bit.lshift(posterizedBlue, posterizationLevel)
+				posterizedAlpha = bit.lshift(posterizedAlpha, posterizationLevel)
 
 				bufferStartPointer[writableAreaStartIndex + 0] = posterizedRed
 				bufferStartPointer[writableAreaStartIndex + 1] = posterizedGreen
 				bufferStartPointer[writableAreaStartIndex + 2] = posterizedBlue
-				bufferStartPointer[writableAreaStartIndex + 3] = alpha
+				bufferStartPointer[writableAreaStartIndex + 3] = posterizedAlpha
 			else -- Slightly wasteful, but the determinism enables testing (and it's barely noticeable anyway)
 				bufferStartPointer[writableAreaStartIndex + 0] = 255
 				bufferStartPointer[writableAreaStartIndex + 1] = 0

--- a/Tests/FileFormats/RagnarokGND.spec.lua
+++ b/Tests/FileFormats/RagnarokGND.spec.lua
@@ -599,7 +599,7 @@ describe("RagnarokGND", function()
 			assertEquals(lightmapTextureImage.height, 8)
 
 			local rawImageBytes = tostring(lightmapTextureImage.rgbaImageBytes)
-			local expectedTextureChecksum = 546589407
+			local expectedTextureChecksum = 288753058
 			local generatedTextureChecksum = miniz.crc32(rawImageBytes)
 			assertEquals(generatedTextureChecksum, expectedTextureChecksum)
 		end)

--- a/Tests/Tools/RagnarokTools.spec.lua
+++ b/Tests/Tools/RagnarokTools.spec.lua
@@ -49,7 +49,7 @@ describe("RagnarokTools", function()
 		it("should export the GND lightmap data in a human-readable format if a valid GND buffer is passed", function()
 			local expectedLightmapChecksum = "be735bab85771a54892d4129d7aba3126e0f7f41f2c9891a28aa8dcfc897d2fa"
 			local expectedShadowmapChecksum = "4a7a36bedbb8e73797b91b2f568b59b8d4600dc3975e2265114339a5142e9175"
-			local expectedTextureChecksum = "a740daf79dda0245b71824d441f42baa9cb9c9449458090b983ec7b80a05b3bc"
+			local expectedTextureChecksum = "dfbff3a58a516c0990147567388431dee2d05dae12a01bd5fb4d30230bb79573"
 
 			local gndFileContents = C_FileSystem.ReadFile(path.join("Tests", "Fixtures", "no-water-plane.gnd"))
 			RagnarokTools:ExportLightmapsFromGND(gndFileContents)


### PR DESCRIPTION
It seems that the "posterization effect" is a due to the use of 16-bit colors. Ergo, the lightmap alpha channel also needs to be posterized since there's no way to store more than 4 bits for each channel.