### PR TITLE
Implement color banding for diffuse texture images

### DIFF
--- a/Core/FileFormats/RagnarokMap.lua
+++ b/Core/FileFormats/RagnarokMap.lua
@@ -4,6 +4,7 @@ local RagnarokGRF = require("Core.FileFormats.RagnarokGRF")
 local RagnarokRSW = require("Core.FileFormats.RagnarokRSW")
 
 local C_Resources = require("Core.NativeClient.C_Resources")
+local Texture = require("Core.NativeClient.WebGPU.Texture")
 
 local NormalsVisualization = require("Core.NativeClient.DebugDraw.NormalsVisualization")
 
@@ -99,6 +100,8 @@ function RagnarokMap:LoadTerrainGeometry(mapID)
 		local normalizedTextureImagePath = RagnarokGRF:DecodeFileName(texturePath)
 		local textureImageBytes = self:FetchResourceByID(normalizedTextureImagePath)
 		local rgbaImageBytes, width, height = C_ImageProcessing.DecodeFileContents(textureImageBytes)
+
+		rgbaImageBytes, width, height = Texture:CreateReducedColorImage(rgbaImageBytes, width, height)
 
 		printf(
 			"[RagnarokMap] Loading GND ground mesh section %d with diffuse texture %s (%d x %d)",

--- a/Tests/FileFormats/RagnarokMap.spec.lua
+++ b/Tests/FileFormats/RagnarokMap.spec.lua
@@ -5,6 +5,16 @@ local RagnarokRSW = require("Core.FileFormats.RagnarokRSW")
 
 local Texture = require("Core.NativeClient.WebGPU.Texture")
 
+local openssl = require("openssl")
+local digest = openssl.digest.digest
+
+local function assertImageChecksumMatches(actualImageBytes, expectedImageBytes)
+	local checksum = digest("sha256", tostring(actualImageBytes))
+	expectedImageBytes = Texture:CreateReducedColorImage(expectedImageBytes, 256, 256)
+	local expectedChecksum = digest("sha256", tostring(expectedImageBytes))
+	assertEquals(checksum, expectedChecksum)
+end
+
 local function makeFileSystem(name)
 	local testFileSystem = {
 		ROOT_DIR = path.join("Tests", "Fixtures", "Borftopia"),
@@ -80,7 +90,7 @@ describe("RagnarokMap", function()
 			assertEquals(#map.meshes, 2 + 1)
 			assertEquals(#map.meshes, #groundMeshSections + #waterPlanes)
 
-			assertEquals(map.meshes[1].diffuseTextureImage.rgbaImageBytes, gradientTexture)
+			assertImageChecksumMatches(map.meshes[1].diffuseTextureImage.rgbaImageBytes, gradientTexture)
 			assertEquals(map.meshes[1].diffuseTextureImage.width, 256)
 			assertEquals(map.meshes[1].diffuseTextureImage.height, 256)
 			assertEquals(map.meshes[1].vertexPositions, groundMeshSections[1].vertexPositions)
@@ -88,7 +98,7 @@ describe("RagnarokMap", function()
 			assertEquals(map.meshes[1].triangleConnections, groundMeshSections[1].triangleConnections)
 			assertEquals(map.meshes[1].diffuseTextureCoords, groundMeshSections[1].diffuseTextureCoords)
 
-			assertEquals(map.meshes[2].diffuseTextureImage.rgbaImageBytes, gridTexture)
+			assertImageChecksumMatches(map.meshes[2].diffuseTextureImage.rgbaImageBytes, gridTexture)
 			assertEquals(map.meshes[2].diffuseTextureImage.width, 256)
 			assertEquals(map.meshes[2].diffuseTextureImage.height, 256)
 			assertEquals(map.meshes[2].vertexPositions, groundMeshSections[2].vertexPositions)

--- a/Tests/NativeClient/WebGPU/Texture.spec.lua
+++ b/Tests/NativeClient/WebGPU/Texture.spec.lua
@@ -204,4 +204,15 @@ describe("Texture", function()
 			end, Texture.ERROR_DIMENSIONS_EXCEEDING_LIMIT)
 		end)
 	end)
+
+	describe("CreateReducedColorImage", function()
+		it("should reduce the color depth of the texture image", function()
+			local testImage = "\255\192\128\000" .. "\007\007\007\007"
+			local reducedColorImage, width, height = Texture:CreateReducedColorImage(testImage, 2, 1)
+			local expectedimageBytes = "\248\192\128\000\000\000\000\000"
+			assertEquals(width, 2)
+			assertEquals(height, 1)
+			assertEquals(tostring(reducedColorImage), expectedimageBytes)
+		end)
+	end)
 end)


### PR DESCRIPTION
Colors being limited to 16 bits per pixel means that all textures need to be posterized, not just the lightmaps. The resulting color banding softens certain highlights, e.g. on xmas_fild01 - removing it causes some spots to look "off" as they're way too bright.

This code isn't optimized at all since the posterization step doesn't seem to take significant time anyway. Can move it into the runtime's image processing API if that ever becomes necessary. For now, there's no use in doing this, at least for GND textures.