### PR TITLE
Implement error correction for posterized lightmap textures

### DIFF
--- a/Tests/FileFormats/RagnarokGND.spec.lua
+++ b/Tests/FileFormats/RagnarokGND.spec.lua
@@ -599,7 +599,7 @@ describe("RagnarokGND", function()
 			assertEquals(lightmapTextureImage.height, 8)
 
 			local rawImageBytes = tostring(lightmapTextureImage.rgbaImageBytes)
-			local expectedTextureChecksum = 288753058
+			local expectedTextureChecksum = 3839217290
 			local generatedTextureChecksum = miniz.crc32(rawImageBytes)
 			assertEquals(generatedTextureChecksum, expectedTextureChecksum)
 		end)

--- a/Tests/Tools/RagnarokTools.spec.lua
+++ b/Tests/Tools/RagnarokTools.spec.lua
@@ -49,7 +49,7 @@ describe("RagnarokTools", function()
 		it("should export the GND lightmap data in a human-readable format if a valid GND buffer is passed", function()
 			local expectedLightmapChecksum = "be735bab85771a54892d4129d7aba3126e0f7f41f2c9891a28aa8dcfc897d2fa"
 			local expectedShadowmapChecksum = "4a7a36bedbb8e73797b91b2f568b59b8d4600dc3975e2265114339a5142e9175"
-			local expectedTextureChecksum = "dfbff3a58a516c0990147567388431dee2d05dae12a01bd5fb4d30230bb79573"
+			local expectedTextureChecksum = "b8323aa6889476237edea7d1ce894c889e3bb7dbd464bbe1068568994999c659"
 
 			local gndFileContents = C_FileSystem.ReadFile(path.join("Tests", "Fixtures", "no-water-plane.gnd"))
 			RagnarokTools:ExportLightmapsFromGND(gndFileContents)


### PR DESCRIPTION
The blending stage interpolates colors linearly when multiplying with the higher-precision inputs (same as for diffuse textures).

---

Follow-up to #388 - this should likely be streamlined, but that can wait until it's moved to the runtime, if ever.