### PR TITLE
Fix a subsection nesting issue in the UI test suite

### DIFF
--- a/Tests/NativeClient/Interface/PerformanceMetricsOverlay.spec.lua
+++ b/Tests/NativeClient/Interface/PerformanceMetricsOverlay.spec.lua
@@ -113,79 +113,79 @@ describe("PerformanceMetricsOverlay", function()
 			local expected = "Memory: 1024 MB | Percentage: 56.75 % | Time: 250 milliseconds"
 			assertEquals(actual, expected)
 		end)
+	end)
 
-		describe("ComputeResourceUsageForInterval", function()
-			local function uvMakeResourceUsage(seconds, microseconds)
-				return {
-					utime = { sec = seconds, usec = microseconds },
-					stime = { sec = 0, usec = 0 }, -- stime is ignored since it may be async background tasks etc.
-				}
-			end
+	describe("ComputeResourceUsageForInterval", function()
+		local function uvMakeResourceUsage(seconds, microseconds)
+			return {
+				utime = { sec = seconds, usec = microseconds },
+				stime = { sec = 0, usec = 0 }, -- stime is ignored since it may be async background tasks etc.
+			}
+		end
 
-			it("should compute the resource usage if the measured interval is zero", function()
-				local initialUsage = uvMakeResourceUsage(1, 500000) -- 1.5 seconds
-				local finalUsage = uvMakeResourceUsage(1, 500000) -- 1.5 seconds
-				local measuredIntervalInMilliseconds = 0 -- 1 second
-				local expected = 0
-				local actual = PerformanceMetricsOverlay:ComputeResourceUsageForInterval(
-					initialUsage,
-					finalUsage,
-					measuredIntervalInMilliseconds
-				)
-				assertEquals(actual, expected)
-			end)
+		it("should compute the resource usage if the measured interval is zero", function()
+			local initialUsage = uvMakeResourceUsage(1, 500000) -- 1.5 seconds
+			local finalUsage = uvMakeResourceUsage(1, 500000) -- 1.5 seconds
+			local measuredIntervalInMilliseconds = 0 -- 1 second
+			local expected = 0
+			local actual = PerformanceMetricsOverlay:ComputeResourceUsageForInterval(
+				initialUsage,
+				finalUsage,
+				measuredIntervalInMilliseconds
+			)
+			assertEquals(actual, expected)
+		end)
 
-			it("should compute the resource usage correctly if it's 0%", function()
-				local initialUsage = uvMakeResourceUsage(1, 500000) -- 1.5 seconds
-				local finalUsage = uvMakeResourceUsage(1, 500000) -- 1.5 seconds
-				local measuredIntervalInMilliseconds = 1000 -- 1 second
-				local expected = 0
-				local actual = PerformanceMetricsOverlay:ComputeResourceUsageForInterval(
-					initialUsage,
-					finalUsage,
-					measuredIntervalInMilliseconds
-				)
-				assertEquals(actual, expected)
-			end)
+		it("should compute the resource usage correctly if it's 0%", function()
+			local initialUsage = uvMakeResourceUsage(1, 500000) -- 1.5 seconds
+			local finalUsage = uvMakeResourceUsage(1, 500000) -- 1.5 seconds
+			local measuredIntervalInMilliseconds = 1000 -- 1 second
+			local expected = 0
+			local actual = PerformanceMetricsOverlay:ComputeResourceUsageForInterval(
+				initialUsage,
+				finalUsage,
+				measuredIntervalInMilliseconds
+			)
+			assertEquals(actual, expected)
+		end)
 
-			it("should compute the resource usage correctly if it's 100%", function()
-				local initialUsage = uvMakeResourceUsage(0, 500000) -- 0.5 seconds
-				local finalUsage = uvMakeResourceUsage(1, 0) -- 1 second
-				local measuredIntervalInMilliseconds = 500 -- 0.5 second
-				local expected = 100 -- 100% CPU usage
-				local actual = PerformanceMetricsOverlay:ComputeResourceUsageForInterval(
-					initialUsage,
-					finalUsage,
-					measuredIntervalInMilliseconds
-				)
-				assertEquals(actual, expected)
-			end)
+		it("should compute the resource usage correctly if it's 100%", function()
+			local initialUsage = uvMakeResourceUsage(0, 500000) -- 0.5 seconds
+			local finalUsage = uvMakeResourceUsage(1, 0) -- 1 second
+			local measuredIntervalInMilliseconds = 500 -- 0.5 second
+			local expected = 100 -- 100% CPU usage
+			local actual = PerformanceMetricsOverlay:ComputeResourceUsageForInterval(
+				initialUsage,
+				finalUsage,
+				measuredIntervalInMilliseconds
+			)
+			assertEquals(actual, expected)
+		end)
 
-			it("should compute the resource usage correctly if it's more than 100%", function()
-				local initialUsage = uvMakeResourceUsage(0, 500000) -- 0.5 seconds
-				local finalUsage = uvMakeResourceUsage(2, 0) -- 1 second
-				local measuredIntervalInMilliseconds = 500 -- 0.5 second
-				local expected = 300 -- 300% CPU usage (probably a measurement error or timer inaccuracy - ignore it)
-				local actual = PerformanceMetricsOverlay:ComputeResourceUsageForInterval(
-					initialUsage,
-					finalUsage,
-					measuredIntervalInMilliseconds
-				)
-				assertEquals(actual, expected)
-			end)
+		it("should compute the resource usage correctly if it's more than 100%", function()
+			local initialUsage = uvMakeResourceUsage(0, 500000) -- 0.5 seconds
+			local finalUsage = uvMakeResourceUsage(2, 0) -- 1 second
+			local measuredIntervalInMilliseconds = 500 -- 0.5 second
+			local expected = 300 -- 300% CPU usage (probably a measurement error or timer inaccuracy - ignore it)
+			local actual = PerformanceMetricsOverlay:ComputeResourceUsageForInterval(
+				initialUsage,
+				finalUsage,
+				measuredIntervalInMilliseconds
+			)
+			assertEquals(actual, expected)
+		end)
 
-			it("should compute the resource usage correctly over the provided duration", function()
-				local initialUsage = uvMakeResourceUsage(1, 0) -- 1 second
-				local finalUsage = uvMakeResourceUsage(2, 0) -- 2 seconds
-				local measuredIntervalInMilliseconds = 2000 -- 2 seconds
-				local expected = 50 -- 50% CPU usage
-				local actual = PerformanceMetricsOverlay:ComputeResourceUsageForInterval(
-					initialUsage,
-					finalUsage,
-					measuredIntervalInMilliseconds
-				)
-				assertEquals(actual, expected)
-			end)
+		it("should compute the resource usage correctly over the provided duration", function()
+			local initialUsage = uvMakeResourceUsage(1, 0) -- 1 second
+			local finalUsage = uvMakeResourceUsage(2, 0) -- 2 seconds
+			local measuredIntervalInMilliseconds = 2000 -- 2 seconds
+			local expected = 50 -- 50% CPU usage
+			local actual = PerformanceMetricsOverlay:ComputeResourceUsageForInterval(
+				initialUsage,
+				finalUsage,
+				measuredIntervalInMilliseconds
+			)
+			assertEquals(actual, expected)
 		end)
 	end)
 end)


### PR DESCRIPTION
This section was accidentally defined as a subsection of `GetFormattedMetricsString`. Both should be at the same nesting level.