### PR TITLE
Remove Windows API calls from debug assertions

### DIFF
--- a/Core/Assertions.hpp
+++ b/Core/Assertions.hpp
@@ -2,7 +2,6 @@
 
 #define ASSERT(condition, failureMessage) \
 	if(!(condition)) {                    \
-		DebugMessage(failureMessage);     \
 		DebugTrap();                      \
 	}
 #define ASSUME(condition, failureMessage) ASSERT(condition, failureMessage)

--- a/Core/Intrinsics.hpp
+++ b/Core/Intrinsics.hpp
@@ -8,9 +8,6 @@ GLOBAL char CPU_BRAND_STRING[0x40] = { "N/A (__cpuid intrinsic not yet supported
 
 #ifdef RAGLITE_COMPILER_MSVC
 
-// TODO Eliminate WinAPI references here
-#include "Platforms/Win32.hpp"
-
 INTERNAL void IntrinsicsReadCPUID() {
 
 	__cpuid(CPU_INFO_MASK, 0x80000000);
@@ -27,7 +24,6 @@ INTERNAL void IntrinsicsReadCPUID() {
 		memcpy(CPU_BRAND_STRING + 32, CPU_INFO_MASK, sizeof(CPU_INFO_MASK));
 	}
 
-#define DebugMessage(message) OutputDebugStringA(message);
 #define DebugTrap() __debugbreak();
 
 #else


### PR DESCRIPTION
These aren't needed when using a debugger, and a popup alert with exit would be more useful for development/CI workflows.