### PR TITLE
Move GetSystemInfo calls out of the render loop

### DIFF
--- a/Core/Platforms/Win32.cpp
+++ b/Core/Platforms/Win32.cpp
@@ -220,6 +220,10 @@ int WINAPI WinMain(HINSTANCE instance, HINSTANCE, LPSTR,
 	ASSUME(didAdjustGranularity, "Failed to adjust the process scheduler's time period");
 	milliseconds sleepTime = MILLISECONDS_PER_SECOND / TARGET_FRAME_RATE;
 
+	SYSTEM_INFO sysInfo;
+	GetSystemInfo(&sysInfo);
+	CPU_PERFORMANCE_METRICS.hardwareSystemInfo = sysInfo;
+
 	WNDCLASSEX windowClass = {};
 	// TODO Is this really a good idea? Beware the CS_OWNDC footguns...
 	// TODO https://devblogs.microsoft.com/oldnewthing/20060601-06/?p=31003

--- a/Core/Platforms/Win32/Time.cpp
+++ b/Core/Platforms/Win32/Time.cpp
@@ -88,9 +88,7 @@ void PerformanceMetricsUpdateNow() {
 
 	// CPU usage
 	CPU_PERFORMANCE_METRICS.processorUsageAllCores = GetProcessorUsageAllCores();
-	SYSTEM_INFO sysInfo;
-	GetSystemInfo(&sysInfo);
-	CPU_PERFORMANCE_METRICS.processorUsageSingleCore = CPU_PERFORMANCE_METRICS.processorUsageAllCores * sysInfo.dwNumberOfProcessors;
+	CPU_PERFORMANCE_METRICS.processorUsageSingleCore = CPU_PERFORMANCE_METRICS.processorUsageAllCores * CPU_PERFORMANCE_METRICS.hardwareSystemInfo.dwNumberOfProcessors;
 
 	// Sleep timings
 	milliseconds desiredSleepTime = MILLISECONDS_PER_SECOND / TARGET_FRAME_RATE;
@@ -102,6 +100,4 @@ void PerformanceMetricsUpdateNow() {
 
 	CPU_PERFORMANCE_METRICS.desiredSleepTime = desiredSleepTime;
 	CPU_PERFORMANCE_METRICS.observedSleepTime = observedSleepTime;
-
-	CPU_PERFORMANCE_METRICS.hardwareSystemInfo = sysInfo;
 }


### PR DESCRIPTION
This isn't going to change, so no need to call it every frame.