### PR TITLE
Remove GDI debug overlay updates from WM_KEYUP

### DIFF
--- a/Core/Platforms/Win32.cpp
+++ b/Core/Platforms/Win32.cpp
@@ -131,9 +131,6 @@ LRESULT CALLBACK WindowProcessMessage(HWND window, UINT message, WPARAM wParam,
 	case WM_SYSKEYUP:
 	case WM_KEYDOWN:
 	case WM_KEYUP: {
-		DebugDrawKeyboardOverlay(GDI_SURFACE);
-		DebugDrawMemoryUsageOverlay(GDI_SURFACE);
-
 		WORD virtualKeyCode = LOWORD(wParam);
 		WORD keyFlags = HIWORD(lParam);
 		WORD scanCode = LOBYTE(keyFlags);


### PR DESCRIPTION
If responsiveness is an issue, this isn't the way to improve it.