### PR TITLE
Skip drawing when the main window is minimized

### DIFF
--- a/Core/Platforms/Win32.cpp
+++ b/Core/Platforms/Win32.cpp
@@ -99,8 +99,10 @@ void BlitBackBufferToWindow(HWND& window) {
 	GDI_SURFACE.displayDeviceContext = deviceContext;
 
 	ASSUME(GDI_SURFACE.displayDeviceContext, "Failed to get GDI display device drawing context");
-	ASSUME(GDI_SURFACE.offscreenDeviceContext, "Failed to get GDI offscreen device drawing context");
-	ASSUME(GDI_BACKBUFFER.activeHandle, "No active GDI back buffer is available for drawing");
+	if(!GDI_BACKBUFFER.activeHandle || !GDI_SURFACE.offscreenDeviceContext) {
+		// Minimized (redraw once restored)
+		return;
+	}
 
 	int srcW = GDI_BACKBUFFER.width;
 	int srcH = GDI_BACKBUFFER.height;


### PR DESCRIPTION
Yeah, shouldn't have removed this in the first place.
Simply minimizing is enough to trigger the assertion.