### PR TITLE
Handle WM_MOVING / WM_MOVE / WM_DISPLAYCHANGE (by force-repainting)

### DIFF
--- a/Core/Platforms/Win32.cpp
+++ b/Core/Platforms/Win32.cpp
@@ -137,6 +137,8 @@ LRESULT CALLBACK WindowProcessMessage(HWND window, UINT message, WPARAM wParam,
 	} break;
 
 	case WM_DISPLAYCHANGE:
+	case WM_MOVE:
+	case WM_MOVING:
 	case WM_SIZING:
 	case WM_SIZE: {
 		SurfaceGetWindowDimensions(GDI_SURFACE, window);


### PR DESCRIPTION
Not the best way to deal with these events, but at least there's a reminder in the code now that can be revisited.