### PR TITLE
Prevent frame time graphs from breaking after the window was minimized

### DIFF
--- a/Core/Platforms/Win32.cpp
+++ b/Core/Platforms/Win32.cpp
@@ -342,15 +342,15 @@ int WINAPI WinMain(HINSTANCE instance, HINSTANCE, LPSTR,
 
 		RedrawEverythingIntoWindow(mainWindow);
 
-		milliseconds frameTime = PerformanceMetricsGetTimeSince(lastUpdateTime);
-		CPU_PERFORMANCE_METRICS.frameTime = frameTime;
-
 		milliseconds maxResponsiveSleepTime = MAX_FRAME_TIME;
 		milliseconds sleepTime = maxResponsiveSleepTime - CPU_PERFORMANCE_METRICS.frameTime;
 		hardware_tick_t beforeSleep = PerformanceMetricsNow();
 		if(sleepTime > 0) Sleep((DWORD)sleepTime);
 		CPU_PERFORMANCE_METRICS.sleepTime = sleepTime;
 		CPU_PERFORMANCE_METRICS.suspendedTime = PerformanceMetricsGetTimeSince(beforeSleep);
+
+		milliseconds frameTime = PerformanceMetricsGetTimeSince(lastUpdateTime);
+		CPU_PERFORMANCE_METRICS.frameTime = frameTime;
 
 		PerformanceMetricsRecordSample(CPU_PERFORMANCE_METRICS, PERFORMANCE_METRICS_HISTORY);
 	}

--- a/Core/Platforms/Win32.cpp
+++ b/Core/Platforms/Win32.cpp
@@ -121,6 +121,13 @@ void DrawDebugOverlay(gdi_surface_t doubleBufferedSurface) {
 }
 
 void RedrawEverythingIntoWindow(HWND& window) {
+	if(IsIconic(window)) {
+		// Minimized - no point in drawing this frame
+		CPU_PERFORMANCE_METRICS.worldRenderTime = 0;
+		CPU_PERFORMANCE_METRICS.userInterfaceRenderTime = 0;
+		return;
+	}
+
 	hardware_tick_t before = PerformanceMetricsNow();
 	DebugDrawIntoFrameBuffer(GDI_BACKBUFFER, PLACEHOLDER_DEMO_APP.offsetX, PLACEHOLDER_DEMO_APP.offsetY);
 	CPU_PERFORMANCE_METRICS.worldRenderTime = PerformanceMetricsGetTimeSince(before);


### PR DESCRIPTION
XY plot spikes, not a big deal. But the area chart is completely broken when the sleep time far surpasses the frame time:

<img width="262" height="84" alt="image" src="https://github.com/user-attachments/assets/1fe1f35f-e266-46ec-b49f-466eb064a8d2" />

I don't know that the UX of handling minimized windows is ideal yet, but that's a problem best saved for later.