### PR TITLE
Add a GDI object count to the Win32 debug overlay

### DIFF
--- a/Core/Platforms/Win32/DebugDraw.cpp
+++ b/Core/Platforms/Win32/DebugDraw.cpp
@@ -337,6 +337,10 @@ INTERNAL void DebugDrawProcessorUsageOverlay(HDC& displayDeviceContext) {
 	TextOutA(displayDeviceContext, startX + DEBUG_OVERLAY_PADDING_SIZE, lineY, formatBuffer, lstrlenA(formatBuffer));
 	lineY += DEBUG_OVERLAY_LINE_HEIGHT;
 
+	StringCbPrintfA(formatBuffer, FORMAT_BUFFER_SIZE, "GDI Objects: %d", GetGuiResources(GetCurrentProcess(), GR_GDIOBJECTS));
+	TextOutA(displayDeviceContext, startX + DEBUG_OVERLAY_PADDING_SIZE, lineY, formatBuffer, lstrlenA(formatBuffer));
+	lineY += DEBUG_OVERLAY_LINE_HEIGHT;
+
 	//-------------------------------------------------
 	// CPU usage stats
 	//-------------------------------------------------
@@ -622,11 +626,7 @@ INTERNAL void DebugDrawProcessorUsageOverlay(HDC& displayDeviceContext) {
 	lineY += DEBUG_OVERLAY_LINE_HEIGHT;
 
 	lineY += DEBUG_OVERLAY_MARGIN_SIZE;
-	StringCbPrintfA(formatBuffer, FORMAT_BUFFER_SIZE, "Page Size: %u KB", CPU_PERFORMANCE_INFO.pageSize);
-	TextOutA(displayDeviceContext, startX + DEBUG_OVERLAY_PADDING_SIZE, lineY, formatBuffer, lstrlenA(formatBuffer));
-	lineY += DEBUG_OVERLAY_LINE_HEIGHT;
-
-	StringCbPrintfA(formatBuffer, FORMAT_BUFFER_SIZE, "Allocation Granularity: %u KB", CPU_PERFORMANCE_INFO.allocationGranularity / Kilobytes(1));
+	StringCbPrintfA(formatBuffer, FORMAT_BUFFER_SIZE, "Page Size: %u KB (Allocation Granularity: %u KB)", CPU_PERFORMANCE_INFO.pageSize, CPU_PERFORMANCE_INFO.allocationGranularity / Kilobytes(1));
 	TextOutA(displayDeviceContext, startX + DEBUG_OVERLAY_PADDING_SIZE, lineY, formatBuffer, lstrlenA(formatBuffer));
 	lineY += DEBUG_OVERLAY_LINE_HEIGHT;
 


### PR DESCRIPTION
Had to shuffle around the HW info text to make some space.