### PR TITLE
Extend the Win32 memory debug overlay to support multiple global arenas

### DIFF
--- a/Core/Platforms/Win32.cpp
+++ b/Core/Platforms/Win32.cpp
@@ -392,6 +392,24 @@ int WINAPI WinMain(HINSTANCE instance, HINSTANCE, LPSTR,
 			PLACEHOLDER_DEMO_APP.offsetY++;
 			PLACEHOLDER_DEMO_APP.offsetY++;
 
+			size_t allocationSize = Megabytes(2);
+			if(!SystemMemoryCanAllocate(MAIN_MEMORY, allocationSize)) {
+				SystemMemoryReset(MAIN_MEMORY);
+			} else {
+				uint8* mainMemory = (uint8*)SystemMemoryAllocate(MAIN_MEMORY, allocationSize);
+				*mainMemory = 0xDE;
+				SystemMemoryDebugTouch(MAIN_MEMORY, mainMemory);
+			}
+
+			if(!SystemMemoryCanAllocate(TRANSIENT_MEMORY, 2 * allocationSize)) {
+				SystemMemoryReset(TRANSIENT_MEMORY);
+			} else {
+
+				uint8* transientMemory = (uint8*)SystemMemoryAllocate(TRANSIENT_MEMORY, 2 * allocationSize);
+				*transientMemory = 0xAB;
+				SystemMemoryDebugTouch(TRANSIENT_MEMORY, transientMemory);
+			}
+
 			GamePadPollControllers(PLACEHOLDER_DEMO_APP.offsetX, PLACEHOLDER_DEMO_APP.offsetY);
 			DebugDrawUpdateBackgroundPattern();
 		}

--- a/Core/Platforms/Win32.cpp
+++ b/Core/Platforms/Win32.cpp
@@ -84,6 +84,7 @@ INTERNAL const char* ArchitectureToDebugName(WORD wProcessorArchitecture) {
 }
 
 #include "Win32/DebugDraw.hpp"
+#include "Win32/Memory.hpp"
 
 #include "Win32/GamePad.cpp"
 #include "Win32/Keyboard.cpp"
@@ -321,6 +322,11 @@ int WINAPI WinMain(HINSTANCE instance, HINSTANCE, LPSTR,
 	QueryPerformanceFrequency(&ticksPerSecond);
 	MONOTONIC_CLOCK_SPEED = ticksPerSecond.QuadPart;
 	hardware_tick_t lastUpdateTime = PerformanceMetricsNow();
+
+	// TODO Override via CLI arguments or something? (Can also compute based on available RAM)
+	constexpr size_t MAIN_MEMORY_SIZE = Megabytes(85);
+	constexpr size_t TRANSIENT_MEMORY_SIZE = Megabytes(1596) + Kilobytes(64 * 14);
+	SystemMemoryInitializeArenas(MAIN_MEMORY_SIZE, TRANSIENT_MEMORY_SIZE);
 
 	WNDCLASSEX windowClass = {};
 	// TODO Is this really a good idea? Beware the CS_OWNDC footguns...

--- a/Core/Platforms/Win32.hpp
+++ b/Core/Platforms/Win32.hpp
@@ -3,6 +3,7 @@
 #define VC_EXTRALEAN
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <psapi.h>
 #include <shlwapi.h>
 #include <strsafe.h>
 #include <timeapi.h>

--- a/Core/Platforms/Win32/DebugDraw.cpp
+++ b/Core/Platforms/Win32/DebugDraw.cpp
@@ -538,6 +538,10 @@ INTERNAL void DebugDrawMemoryArenaHeatmap(HDC& displayDeviceContext, memory_aren
 	TextOutA(displayDeviceContext, startX + DEBUG_OVERLAY_PADDING_SIZE, lineY, formatBuffer, lstrlenA(formatBuffer));
 	lineY += DEBUG_OVERLAY_LINE_HEIGHT;
 
+	progress_bar_t progressBar = { .x = startX + DEBUG_OVERLAY_PADDING_SIZE, .y = lineY, .width = PROGRESS_BAR_WIDTH, .height = PROGRESS_BAR_HEIGHT, .percent = Percent(committedPercent) };
+	DrawProgressBar(displayDeviceContext, progressBar);
+	lineY += DEBUG_OVERLAY_LINE_HEIGHT;
+
 	lineY += DEBUG_OVERLAY_MARGIN_SIZE;
 	percentage usedPercent = DoubleToFloat((double)(arena.used) / Max(arena.committedSize, EPSILON));
 	StringCbPrintfA(formatBuffer, FORMAT_BUFFER_SIZE, "Allocated: %d MB / %d MB (%d%%)",
@@ -546,6 +550,8 @@ INTERNAL void DebugDrawMemoryArenaHeatmap(HDC& displayDeviceContext, memory_aren
 	TextOutA(displayDeviceContext, startX + DEBUG_OVERLAY_PADDING_SIZE, lineY, formatBuffer, lstrlenA(formatBuffer));
 	lineY += DEBUG_OVERLAY_LINE_HEIGHT;
 
+	progressBar = { .x = startX + DEBUG_OVERLAY_PADDING_SIZE, .y = lineY, .width = PROGRESS_BAR_WIDTH, .height = PROGRESS_BAR_HEIGHT, .percent = Percent(usedPercent) };
+	DrawProgressBar(displayDeviceContext, progressBar);
 	lineY += DEBUG_OVERLAY_LINE_HEIGHT;
 
 	const size_t blockSize = CPU_PERFORMANCE_INFO.allocationGranularity;

--- a/Core/Platforms/Win32/Memory.cpp
+++ b/Core/Platforms/Win32/Memory.cpp
@@ -89,3 +89,30 @@ INTERNAL void SystemMemoryInitializeArenas(size_t mainMemorySize, size_t transie
 	MAIN_MEMORY.committedSize = mainMemorySize;
 	TRANSIENT_MEMORY.committedSize = transientMemorySize;
 }
+
+INTERNAL void* SystemMemoryAllocate(memory_arena_t& arena, size_t allocationSize) {
+	size_t totalUsed = arena.used + allocationSize;
+	ASSUME(totalUsed <= arena.reservedSize, "Attempting to allocate outside the reserved set");
+
+	void* memoryRegionStartPointer = (uint8*)arena.baseAddress + arena.used;
+	arena.used = totalUsed;
+	arena.allocationCount++;
+
+	return memoryRegionStartPointer;
+}
+
+INTERNAL bool SystemMemoryCanAllocate(memory_arena_t& arena, size_t allocationSize) {
+	if(arena.used + allocationSize > arena.reservedSize) return false;
+	return true;
+}
+
+void SystemMemoryReset(memory_arena_t& arena) {
+	arena.allocationCount = 0;
+	arena.used = 0;
+}
+
+INTERNAL inline void SystemMemoryDebugTouch(memory_arena_t& arena, uint8* address) {
+	ASSUME(address >= arena.baseAddress, "Attempted to access an invalid arena offset");
+	size_t offset = address - (uint8*)arena.baseAddress;
+	// TODO: Update last accessed time
+}

--- a/Core/Platforms/Win32/Memory.cpp
+++ b/Core/Platforms/Win32/Memory.cpp
@@ -1,22 +1,91 @@
-#include <psapi.h>
+constexpr size_t HIGHEST_VIRTUAL_ADDRESS = Terabytes(1);
+constexpr size_t INVALID_VIRTUAL_ADDRESS = 0xDEADBEEFULL;
 
-typedef struct virtual_memory_arena {
-	const char* name;
-	const char* lifetime;
-	void* baseAddress;
-	size_t reservedSize;
-	size_t committedSize;
-	size_t used;
-	size_t allocationCount;
-} memory_arena_t;
-
-// TODO Actually create the arena (via VirtualAlloc)
 GLOBAL memory_arena_t MAIN_MEMORY = {
-	.name = "Preallocated (Main Memory)",
-	.lifetime = "Forever (Global Arena)",
-	.baseAddress = (void*)0xDEADBEEFull,
-	.reservedSize = 64u * 1024 * 42 * 1024,
-	.committedSize = 64u * 1024 * 42 * 512,
-	.used = 64 * 1024 * 42 * 256,
-	.allocationCount = 42
+	.displayName = StringLiteral("Main Memory"),
+	.lifetime = KEEP_FOREVER_MANUAL_RESET,
+	.usage = UNUSED_PLACEHOLDER,
+	.baseAddress = (void*)INVALID_VIRTUAL_ADDRESS,
+	.reservedSize = 0,
+	.committedSize = 0,
+	.used = 0,
+	.allocationCount = 0
 };
+
+GLOBAL memory_arena_t TRANSIENT_MEMORY = {
+	.displayName = StringLiteral("Transient Memory"),
+	.lifetime = RESET_AFTER_EACH_FRAME,
+	.usage = UNUSED_PLACEHOLDER,
+	.baseAddress = (void*)INVALID_VIRTUAL_ADDRESS,
+	.reservedSize = 0,
+	.committedSize = 0,
+	.used = 0,
+	.allocationCount = 0
+};
+
+// TBD Guard with feature flag (check if compiler removes when unused - assumption: yes)
+INTERNAL String SystemMemoryDebugUsage(memory_arena_t& arena) {
+	switch(arena.lifetime) {
+	case UNUSED_PLACEHOLDER:
+		return StringLiteral("Unused (Placeholder)");
+	case PREALLOCATED_ON_LOAD:
+		return StringLiteral("Preallocated (Default)");
+	case DYNAMIC_RESIZE_FREELIST:
+		return StringLiteral("Dynamic (Resizeable)");
+	case CAN_HOT_RELOAD:
+		return StringLiteral("Reloadable (Pinned)");
+	default:
+		return StringLiteral("N/A");
+	}
+}
+
+INTERNAL String SystemMemoryDebugLifetime(memory_arena_t& arena) {
+	switch(arena.lifetime) {
+	case KEEP_FOREVER_MANUAL_RESET:
+		return StringLiteral("Forever (Global Arena)");
+	case RESET_AFTER_EACH_FRAME:
+		return StringLiteral("Frame (Scoped Arena)");
+	case RESET_AFTER_TASK_COMPLETION:
+		return StringLiteral("Task Completion (Transfer Arena)");
+	case RESET_AUTOMATICALLY_TIMED_EXPIRY:
+		return StringLiteral("Auto-Expires (Caching Arena)");
+	default:
+		return StringLiteral("N/A");
+	}
+}
+
+INTERNAL void SystemMemoryInitializeArenas(size_t mainMemorySize, size_t transientMemorySize) {
+
+#ifdef RAGLITE_PREDICTABLE_MEMORY
+	LPVOID baseAddress = 0;
+#else
+	LPVOID baseAddress = (LPVOID)HIGHEST_VIRTUAL_ADDRESS;
+#endif
+
+	DWORD allocationTypeFlags = MEM_RESERVE | MEM_COMMIT;
+	DWORD memoryProtectionFlags = PAGE_READWRITE;
+	MAIN_MEMORY = {
+		.displayName = StringLiteral("Main Memory"),
+		.lifetime = KEEP_FOREVER_MANUAL_RESET,
+		.usage = PREALLOCATED_ON_LOAD,
+		.baseAddress = VirtualAlloc(baseAddress, mainMemorySize + transientMemorySize, allocationTypeFlags, memoryProtectionFlags),
+		.reservedSize = mainMemorySize,
+		.committedSize = 0,
+		.used = 0,
+		.allocationCount = 0
+	};
+
+	TRANSIENT_MEMORY = {
+		.displayName = StringLiteral("Transient Memory"),
+		.lifetime = KEEP_FOREVER_MANUAL_RESET,
+		.usage = PREALLOCATED_ON_LOAD,
+		.baseAddress = (uint8*)MAIN_MEMORY.baseAddress + mainMemorySize,
+		.reservedSize = transientMemorySize,
+		.committedSize = 0,
+		.used = 0,
+		.allocationCount = 0
+	};
+
+	MAIN_MEMORY.committedSize = mainMemorySize;
+	TRANSIENT_MEMORY.committedSize = transientMemorySize;
+}

--- a/Core/Platforms/Win32/Memory.hpp
+++ b/Core/Platforms/Win32/Memory.hpp
@@ -1,0 +1,28 @@
+// NOTE: These are mutually exclusive - do not combine them ever (unhappiness will find you)
+enum arena_lifetime_flag {
+	KEEP_FOREVER_MANUAL_RESET = 0, // Default choice (make sure the arena is small)
+	RESET_AFTER_EACH_FRAME, // Transient memory likely wants to use this mode
+	RESET_AFTER_TASK_COMPLETION, // Async workloads/resource loading (NYI)
+	RESET_AUTOMATICALLY_TIMED_EXPIRY, // For persistent resources/prefetcher/memory pressure mode (NYI)
+};
+
+// TBD: Not sure if these are useful for anything other than debug annotations (revisit later)
+enum arena_usage_flag {
+	UNUSED_PLACEHOLDER = 0,
+	PREALLOCATED_ON_LOAD, // Sane default (choose whenever possible)
+	DYNAMIC_RESIZE_FREELIST, // NYI: Can remove this ideally? (not sure yet, keep as a reminder for now)
+	CAN_HOT_RELOAD, // NOTE: Must not change structures with this flag or things will go horribly wrong
+};
+
+typedef struct virtual_memory_arena {
+	// TBD: Gate debug-time features via flags? Unlikely to matter for the time being (revisit later)
+	String displayName;
+	arena_lifetime_flag lifetime;
+	arena_usage_flag usage;
+	// TBD: Store this header in the arena itself (required for free-lists/resizes - later)?
+	void* baseAddress;
+	size_t reservedSize;
+	size_t committedSize;
+	size_t used;
+	size_t allocationCount;
+} memory_arena_t;

--- a/Core/RagLite2.hpp
+++ b/Core/RagLite2.hpp
@@ -37,6 +37,7 @@
 // TODO: Add feature flags for release builds here
 #else
 #define RAGLITE_DEBUG_ASSERTIONS
+#define RAGLITE_PREDICTABLE_MEMORY
 #endif
 
 constexpr size_t BITS_PER_BYTE = 8ULL;


### PR DESCRIPTION
Many features are missing in this early version, but the display itself should be able to handle 4-5 arenas easily.
That's likely more than enough for now. I'll deal with alignment, access patterns, logging, block scaling, etc later.